### PR TITLE
Replace -apikey with generic -headers flag for backend-agnostic OTLP …

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,18 @@ The combination of `/adversary`, `/red-team`, and `/nasa-se` is why a single dev
 # Download the latest release (or build from source)
 go install github.com/ImmersiveFusion/if-opentelemetry-tracegen/cmd/tracegen@latest
 
-# Run with your OTLP endpoint
-tracegen -apikey YOUR_API_KEY -endpoint your-otlp-endpoint:443
+# Send to a local OTLP collector (Jaeger, Tempo, etc.)
+tracegen -insecure
 
-# Or set the API key via environment variable
-export OTEL_APIKEY=YOUR_API_KEY
+# Send to a remote endpoint with auth headers
+tracegen -endpoint your-otlp-endpoint:443 -headers "api-key=YOUR_KEY"
+
+# Or set headers via the standard OTel environment variable
+export OTEL_EXPORTER_OTLP_HEADERS="api-key=YOUR_KEY"
 tracegen -endpoint your-otlp-endpoint:443
 ```
 
-> **See it in 3D** - The default endpoint (`otlp.iapm.app`) sends traces straight to [Immersive APM](https://immersivefusion.com), where you can explore them as a 3D force-directed graph, drill into conventional trace waterfalls for detailed analysis, and get AI-assisted insights from [Tessa](https://immersivefusion.com). For a ready-made example without any setup, try the [OpenTelemetry Chaos Simulator](https://github.com/ImmersiveFusion/if-opentelemetry-chaos-simulator-sample) at [demo.iapm.app](https://demo.iapm.app) - a fully interactive sandbox with visual failure injection.
+> **See it in 3D** - Send traces to [Immersive APM](https://immersivefusion.com) (`tracegen -endpoint otlp.iapm.app:443 -headers "api-key=YOUR_KEY"`) to explore them as a 3D force-directed graph, drill into conventional trace waterfalls for detailed analysis, and get AI-assisted insights from [Tessa](https://immersivefusion.com). For a ready-made example without any setup, try the [OpenTelemetry Chaos Simulator](https://github.com/ImmersiveFusion/if-opentelemetry-chaos-simulator-sample) at [demo.iapm.app](https://demo.iapm.app) - a fully interactive sandbox with visual failure injection.
 
 ## Features
 
@@ -213,8 +216,8 @@ The generated traces simulate a .NET-based e-commerce platform with AI capabilit
 tracegen [flags]
 
 Flags:
-  -apikey string       API key for OTLP endpoint (required, or set OTEL_APIKEY env var)
-  -endpoint string     OTLP gRPC endpoint host:port (default "otlp.iapm.app:443")
+  -endpoint string     OTLP gRPC endpoint host:port (default "localhost:4317")
+  -headers string      OTLP headers as key=value pairs, comma-separated (or set OTEL_EXPORTER_OTLP_HEADERS)
   -complexity string   Topology complexity: light, normal, heavy (default "normal")
   -level int           Aggressiveness 1-10 (default 1)
   -errors int          Error rate 0-10 (default 0)
@@ -256,32 +259,42 @@ Flags:
 ### Examples
 
 ```bash
+# Send to a local Jaeger/Tempo/Collector (default endpoint localhost:4317)
+tracegen -insecure
+
 # Clean demo with minimal services - great for presentations
-tracegen -apikey $KEY -complexity light -level 1
+tracegen -complexity light -level 1 -insecure
 
 # Full e-commerce topology (default)
-tracegen -apikey $KEY -level 1
+tracegen -level 1 -insecure
 
 # Everything including AI agentic scenarios
-tracegen -apikey $KEY -complexity heavy -level 3
+tracegen -complexity heavy -level 3 -insecure
 
 # Moderate load with normal error rates
-tracegen -apikey $KEY -level 5 -errors 5
+tracegen -level 5 -errors 5 -insecure
 
 # Simulate dead consumers (messages pile up, consumers never fire)
-tracegen -apikey $KEY -level 3 -no-consumers
+tracegen -level 3 -no-consumers -insecure
 
 # AI scenarios only - great for LLM observability testing
-tracegen -apikey $KEY -level 3 -ai-only
+tracegen -level 3 -ai-only -insecure
 
 # Simulate AI backend outage (LLM rate limits, timeouts)
-tracegen -apikey $KEY -level 5 -no-ai-backends -errors 5
+tracegen -level 5 -no-ai-backends -errors 5 -insecure
 
 # Chaos mode - maximum load and errors
-tracegen -apikey $KEY -level 10 -errors 10
+tracegen -level 10 -errors 10 -insecure
 
-# Send to a local Jaeger/Tempo instance (any non-empty apikey value works)
-tracegen -apikey local -endpoint localhost:4317 -insecure
+# Send to a remote endpoint with authentication
+tracegen -endpoint otlp.example.com:443 -headers "api-key=YOUR_KEY"
+
+# Multiple headers via environment variable
+export OTEL_EXPORTER_OTLP_HEADERS="api-key=SECRET,x-team=platform"
+tracegen -endpoint otlp.example.com:443
+
+# Send to Immersive APM (3D trace visualization)
+tracegen -endpoint otlp.iapm.app:443 -headers "API-Key=YOUR_IAPM_KEY"
 ```
 
 ## How It Compares

--- a/cmd/tracegen/main.go
+++ b/cmd/tracegen/main.go
@@ -11,6 +11,7 @@ import (
 	"math/rand"
 	"os"
 	"os/signal"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -40,10 +41,15 @@ func tracer(svc string) trace.Tracer {
 	return pool[rand.Intn(len(pool))]
 }
 
-func newProvider(ctx context.Context, serviceName, endpoint, apiKey, instanceID, hostName string) *sdktrace.TracerProvider {
+// parsed headers shared by all providers
+var otlpHeaders map[string]string
+
+func newProvider(ctx context.Context, serviceName, endpoint, instanceID, hostName string) *sdktrace.TracerProvider {
 	opts := []otlptracegrpc.Option{
 		otlptracegrpc.WithEndpoint(endpoint),
-		otlptracegrpc.WithHeaders(map[string]string{"API-Key": apiKey}),
+	}
+	if len(otlpHeaders) > 0 {
+		opts = append(opts, otlptracegrpc.WithHeaders(otlpHeaders))
 	}
 	if insecureMode {
 		opts = append(opts, otlptracegrpc.WithTLSCredentials(insecure.NewCredentials()))
@@ -115,8 +121,8 @@ func errorChance(baseRate float64) bool {
 }
 
 func main() {
-	endpointFlag := flag.String("endpoint", "otlp.iapm.app:443", "OTLP gRPC endpoint (host:port)")
-	apiKeyFlag := flag.String("apikey", "", "API key for OTLP endpoint (required)")
+	endpointFlag := flag.String("endpoint", "localhost:4317", "OTLP gRPC endpoint (host:port)")
+	headersFlag := flag.String("headers", "", "OTLP headers as key=value pairs, comma-separated (e.g. \"api-key=SECRET,x-org=myorg\")")
 	level := flag.Int("level", 1, "aggressiveness 1-10 (1=whisper, 10=SCREAM)")
 	errors := flag.Int("errors", 0, "error rate 0-10 (0=none, 5=normal, 10=chaos)")
 	noConsumers := flag.Bool("no-consumers", false, "disable all async consumers (messages published but never consumed)")
@@ -135,18 +141,11 @@ func main() {
 	}
 
 	endpoint := *endpointFlag
-	apiKey := *apiKeyFlag
-	if apiKey == "" {
-		// Check environment variable as fallback
-		apiKey = os.Getenv("OTEL_APIKEY")
-	}
-	if apiKey == "" {
-		fmt.Fprintln(os.Stderr, "Error: API key required. Use -apikey flag or set OTEL_APIKEY environment variable.")
-		fmt.Fprintln(os.Stderr, "")
-		fmt.Fprintln(os.Stderr, "  tracegen -apikey YOUR_KEY [-complexity light|normal|heavy] [-level N] [-errors N]")
-		fmt.Fprintln(os.Stderr, "")
-		fmt.Fprintln(os.Stderr, "Get your API key at https://iapm.app")
-		os.Exit(1)
+
+	// Parse headers: -headers flag takes precedence, then OTEL_EXPORTER_OTLP_HEADERS env var
+	otlpHeaders = parseHeaders(*headersFlag)
+	if len(otlpHeaders) == 0 {
+		otlpHeaders = parseHeaders(os.Getenv("OTEL_EXPORTER_OTLP_HEADERS"))
 	}
 
 	cfg, ok := levels[*level]
@@ -268,7 +267,7 @@ func main() {
 	}
 
 	for _, p := range pods {
-		newProvider(ctx, p.svc, endpoint, apiKey, p.id, p.node)
+		newProvider(ctx, p.svc, endpoint, p.id, p.node)
 	}
 	defer func() {
 		for _, tp := range providers {
@@ -2432,6 +2431,25 @@ var paymentExceptions = []exceptionInfo{
    at PaymentService.Services.PaymentProcessor.ProcessAsync(Order order) in /src/PaymentService/Services/PaymentProcessor.cs:line 48
    at PaymentService.Workers.PaymentWorker.HandleMessage(RabbitMQ.Message msg) in /src/PaymentService/Workers/PaymentWorker.cs:line 33`,
 	},
+}
+
+// parseHeaders parses "key=value,key2=value2" into a map.
+// Compatible with OTEL_EXPORTER_OTLP_HEADERS env var format.
+func parseHeaders(s string) map[string]string {
+	if s == "" {
+		return nil
+	}
+	headers := map[string]string{}
+	for _, pair := range strings.Split(s, ",") {
+		k, v, ok := strings.Cut(strings.TrimSpace(pair), "=")
+		if ok && k != "" {
+			headers[strings.TrimSpace(k)] = strings.TrimSpace(v)
+		}
+	}
+	if len(headers) == 0 {
+		return nil
+	}
+	return headers
 }
 
 func randomException(exceptions []exceptionInfo) exceptionInfo {


### PR DESCRIPTION
…auth

Removes IAPM-specific API key requirement. Headers are now optional and passed via -headers flag or standard OTEL_EXPORTER_OTLP_HEADERS env var. Default endpoint changed to localhost:4317 for zero-config local usage.