### PR TITLE
Add consumer spans to all fire-and-forget analytics producer events

### DIFF
--- a/cmd/tracegen/scenarios.go
+++ b/cmd/tracegen/scenarios.go
@@ -1178,6 +1178,22 @@ func addToCartFlow(ctx context.Context) {
 	)
 	sleep(2, 5)
 	analytics.End()
+
+	if !consumersEnabled {
+		return
+	}
+	sleep(20, 80)
+	_, analyticsConsumer := tracer("analytics-service").Start(ctx, "ProcessEvent cart.item_added",
+		trace.WithSpanKind(trace.SpanKindConsumer),
+		trace.WithAttributes(
+			attribute.String("messaging.system", "kafka"),
+			attribute.String("messaging.operation", "receive"),
+			attribute.String("messaging.destination", "analytics.events"),
+			attribute.String("analytics.event_type", "cart.item_added"),
+		),
+	)
+	sleep(5, 15)
+	analyticsConsumer.End()
 }
 
 // Full checkout flow — THE monster chain touching nearly every service.
@@ -1448,6 +1464,22 @@ func fullCheckoutFlow(ctx context.Context) {
 	sleep(2, 5)
 	analyticsEvt.End()
 
+	if consumersEnabled {
+		sleep(20, 80)
+		_, analyticsConsumer := tracer("analytics-service").Start(ctx, "ProcessEvent checkout.complete",
+			trace.WithSpanKind(trace.SpanKindConsumer),
+			trace.WithAttributes(
+				attribute.String("messaging.system", "kafka"),
+				attribute.String("messaging.operation", "receive"),
+				attribute.String("messaging.destination", "analytics.events"),
+				attribute.String("analytics.event_type", "checkout.complete"),
+				attribute.String("order.id", orderID),
+			),
+		)
+		sleep(5, 20)
+		analyticsConsumer.End()
+	}
+
 	// Queue notification
 	_, publish := tracer("order-service").Start(ctx, "rabbitmq publish orders.created",
 		trace.WithSpanKind(trace.SpanKindProducer),
@@ -1609,6 +1641,21 @@ func shippingUpdateFlow(ctx context.Context) {
 	)
 	sleep(2, 5)
 	analytics.End()
+
+	if consumersEnabled {
+		sleep(20, 80)
+		_, analyticsConsumer := tracer("analytics-service").Start(ctx, "ProcessEvent shipping.status_changed",
+			trace.WithSpanKind(trace.SpanKindConsumer),
+			trace.WithAttributes(
+				attribute.String("messaging.system", "kafka"),
+				attribute.String("messaging.operation", "receive"),
+				attribute.String("messaging.destination", "analytics.events"),
+				attribute.String("analytics.event_type", "shipping.status_changed"),
+			),
+		)
+		sleep(5, 15)
+		analyticsConsumer.End()
+	}
 }
 
 // Saga compensation — payment fails after order+inventory committed, triggering reverse compensations.
@@ -1857,6 +1904,22 @@ func sagaCompensationFlow(ctx context.Context) {
 	)
 	sleep(2, 5)
 	analyticsCancel.End()
+
+	if consumersEnabled {
+		sleep(20, 80)
+		_, analyticsConsumer := tracer("analytics-service").Start(ctx, "ProcessEvent order.cancelled",
+			trace.WithSpanKind(trace.SpanKindConsumer),
+			trace.WithAttributes(
+				attribute.String("messaging.system", "kafka"),
+				attribute.String("messaging.operation", "receive"),
+				attribute.String("messaging.destination", "analytics.events"),
+				attribute.String("analytics.event_type", "order.cancelled"),
+				attribute.String("order.id", orderID),
+			),
+		)
+		sleep(5, 15)
+		analyticsConsumer.End()
+	}
 }
 
 // Timeout cascade — search-service is slow, gateway times out, frontend retries with cache fallback.
@@ -1962,4 +2025,19 @@ func timeoutCascadeFlow(ctx context.Context) {
 	)
 	sleep(2, 5)
 	analytics.End()
+
+	if consumersEnabled {
+		sleep(20, 80)
+		_, analyticsConsumer := tracer("analytics-service").Start(ctx, "ProcessEvent search.degraded",
+			trace.WithSpanKind(trace.SpanKindConsumer),
+			trace.WithAttributes(
+				attribute.String("messaging.system", "kafka"),
+				attribute.String("messaging.operation", "receive"),
+				attribute.String("messaging.destination", "analytics.events"),
+				attribute.String("analytics.event_type", "search.degraded"),
+			),
+		)
+		sleep(5, 15)
+		analyticsConsumer.End()
+	}
 }

--- a/cmd/tracegen/scenarios_ai.go
+++ b/cmd/tracegen/scenarios_ai.go
@@ -160,6 +160,21 @@ func ragSearchFlow(ctx context.Context) {
 	)
 	sleep(2, 5)
 	analytics.End()
+
+	if consumersEnabled {
+		sleep(20, 80)
+		_, analyticsConsumer := tracer("analytics-service").Start(ctx, "ProcessEvent semantic_search.complete",
+			trace.WithSpanKind(trace.SpanKindConsumer),
+			trace.WithAttributes(
+				attribute.String("messaging.system", "kafka"),
+				attribute.String("messaging.operation", "receive"),
+				attribute.String("messaging.destination", "analytics.events"),
+				attribute.String("analytics.event_type", "semantic_search.complete"),
+			),
+		)
+		sleep(5, 15)
+		analyticsConsumer.End()
+	}
 }
 
 // ─── AI-02: AI Chatbot with Tool Use ──────────────────────────────────────────
@@ -464,6 +479,21 @@ func contentModerationFlow(ctx context.Context) {
 		sleep(3, 8)
 		queue.End()
 
+		if consumersEnabled {
+			sleep(20, 80)
+			_, reviewer := tracer("notification-service").Start(ctx, "ProcessReview flagged_content",
+				trace.WithSpanKind(trace.SpanKindConsumer),
+				trace.WithAttributes(
+					attribute.String("messaging.system", "rabbitmq"),
+					attribute.String("messaging.operation", "receive"),
+					attribute.String("messaging.destination", "moderation.review_queue"),
+					attribute.String("review.status", "pending_human_review"),
+				),
+			)
+			sleep(5, 15)
+			reviewer.End()
+		}
+
 		gateway.SetAttributes(attribute.Int("http.status_code", 202))
 
 	case "block":
@@ -680,6 +710,21 @@ func multiStepAgentFlow(ctx context.Context) {
 	)
 	sleep(2, 5)
 	analytics.End()
+
+	if consumersEnabled {
+		sleep(20, 80)
+		_, analyticsConsumer := tracer("analytics-service").Start(ctx, "ProcessEvent agent.task_complete",
+			trace.WithSpanKind(trace.SpanKindConsumer),
+			trace.WithAttributes(
+				attribute.String("messaging.system", "kafka"),
+				attribute.String("messaging.operation", "receive"),
+				attribute.String("messaging.destination", "analytics.events"),
+				attribute.String("analytics.event_type", "agent.task_complete"),
+			),
+		)
+		sleep(5, 15)
+		analyticsConsumer.End()
+	}
 }
 
 // ─── T-03: Return/Refund ─────────────────────────────────────────────────────
@@ -864,4 +909,20 @@ func returnRefundFlow(ctx context.Context) {
 	)
 	sleep(2, 5)
 	analytics.End()
+
+	if consumersEnabled {
+		sleep(20, 80)
+		_, analyticsConsumer := tracer("analytics-service").Start(ctx, "ProcessEvent order.refunded",
+			trace.WithSpanKind(trace.SpanKindConsumer),
+			trace.WithAttributes(
+				attribute.String("messaging.system", "kafka"),
+				attribute.String("messaging.operation", "receive"),
+				attribute.String("messaging.destination", "analytics.events"),
+				attribute.String("analytics.event_type", "order.refunded"),
+				attribute.String("order.id", orderID),
+			),
+		)
+		sleep(5, 15)
+		analyticsConsumer.End()
+	}
 }


### PR DESCRIPTION
9 TrackEvent/QueueForReview producer spans were missing matching consumer spans, causing orphaned publishes in APM visualizations even with consumers enabled. Each now has a ProcessEvent consumer gated by consumersEnabled.