### PR TITLE
fix: consumer spans declare the queue they drain (no false phantoms)

### DIFF
--- a/cmd/tracegen/scenarios.go
+++ b/cmd/tracegen/scenarios.go
@@ -132,7 +132,9 @@ func createOrderFlow(ctx context.Context) {
 		trace.WithAttributes(
 			attribute.String("messaging.system", "rabbitmq"),
 			attribute.String("messaging.operation", "receive"),
-			attribute.String("messaging.destination", "payments.process"),
+			// Consume the queue the producer actually published (orders.created),
+			// so producer/consumer correlate and no phantom is raised.
+			attribute.String("messaging.destination", "orders.created"),
 			attribute.String("payment.provider", "stripe"),
 		),
 	)
@@ -544,6 +546,10 @@ func bulkNotificationFlow(ctx context.Context) {
 		_, notify := tracer("notification-service").Start(ctx, fmt.Sprintf("SendDigestEmail #%d", i+1),
 			trace.WithSpanKind(trace.SpanKindConsumer),
 			trace.WithAttributes(
+				// Correlate with the notifications.digest producer above.
+				attribute.String("messaging.system", "rabbitmq"),
+				attribute.String("messaging.operation", "receive"),
+				attribute.String("messaging.destination", "notifications.digest"),
 				attribute.String("peer.service", "sendgrid"),
 				attribute.String("notification.type", "daily_digest"),
 				attribute.Int("notification.batch_index", i),
@@ -814,6 +820,8 @@ func scheduledReportFlow(ctx context.Context) {
 		trace.WithAttributes(
 			attribute.String("messaging.system", "rabbitmq"),
 			attribute.String("messaging.operation", "receive"),
+			// Correlate with the reports.ready producer above.
+			attribute.String("messaging.destination", "reports.ready"),
 			attribute.String("peer.service", "sendgrid"),
 			attribute.String("notification.type", "daily_report"),
 		),
@@ -924,6 +932,8 @@ func stripeWebhookFlow(ctx context.Context) {
 		trace.WithAttributes(
 			attribute.String("messaging.system", "rabbitmq"),
 			attribute.String("messaging.operation", "receive"),
+			// Correlate with the orders.confirmed producer above.
+			attribute.String("messaging.destination", "orders.confirmed"),
 			attribute.String("peer.service", "sendgrid"),
 			attribute.String("notification.type", "payment_receipt"),
 		),
@@ -1503,6 +1513,8 @@ func fullCheckoutFlow(ctx context.Context) {
 		trace.WithAttributes(
 			attribute.String("messaging.system", "rabbitmq"),
 			attribute.String("messaging.operation", "receive"),
+			// Correlate with the orders.created producer above.
+			attribute.String("messaging.destination", "orders.created"),
 			attribute.String("notification.type", "order_confirmation"),
 			attribute.String("order.id", orderID),
 		),
@@ -1613,6 +1625,8 @@ func shippingUpdateFlow(ctx context.Context) {
 		trace.WithAttributes(
 			attribute.String("messaging.system", "rabbitmq"),
 			attribute.String("messaging.operation", "receive"),
+			// Correlate with the shipping.updated producer above.
+			attribute.String("messaging.destination", "shipping.updated"),
 			attribute.String("notification.type", "shipping_update"),
 		),
 	)
@@ -1805,6 +1819,7 @@ func sagaCompensationFlow(ctx context.Context) {
 			trace.WithSpanKind(trace.SpanKindConsumer),
 			trace.WithAttributes(
 				attribute.String("messaging.system", "rabbitmq"),
+				attribute.String("messaging.destination", "saga.compensate"),
 				attribute.String("saga.action", "cancel_order"),
 				attribute.String("order.id", orderID),
 			),
@@ -1830,6 +1845,7 @@ func sagaCompensationFlow(ctx context.Context) {
 			trace.WithSpanKind(trace.SpanKindConsumer),
 			trace.WithAttributes(
 				attribute.String("messaging.system", "rabbitmq"),
+				attribute.String("messaging.destination", "saga.compensate"),
 				attribute.String("saga.action", "release_stock"),
 				attribute.String("order.id", orderID),
 			),
@@ -1855,6 +1871,7 @@ func sagaCompensationFlow(ctx context.Context) {
 			trace.WithSpanKind(trace.SpanKindConsumer),
 			trace.WithAttributes(
 				attribute.String("messaging.system", "rabbitmq"),
+				attribute.String("messaging.destination", "saga.compensate"),
 				attribute.String("saga.action", "void_shipping"),
 				attribute.String("order.id", orderID),
 			),
@@ -1870,6 +1887,7 @@ func sagaCompensationFlow(ctx context.Context) {
 			trace.WithSpanKind(trace.SpanKindConsumer),
 			trace.WithAttributes(
 				attribute.String("messaging.system", "rabbitmq"),
+				attribute.String("messaging.destination", "saga.compensate"),
 				attribute.String("notification.type", "order_cancelled"),
 				attribute.String("order.id", orderID),
 			),


### PR DESCRIPTION
Producer/consumer destinations were mismatched or missing, so every produced queue except analytics.events looked unconsumed. The APM client's phantom detector (HP-3) correctly raised a "no-consumer" phantom for each one even on a clean run with consumers enabled.

Align each consumer's messaging.destination with the producer it drains:
- createOrderFlow: ProcessPayment now consumes orders.created (was payments.process)
- fullCheckoutFlow: SendOrderConfirmation -> orders.created
- bulkNotificationFlow: SendDigestEmail -> notifications.digest (+ system/op)
- scheduledReportFlow: SendDailyReportEmail -> reports.ready
- stripeWebhookFlow: SendPaymentReceiptEmail -> orders.confirmed
- shippingUpdateFlow: SendShippingUpdate -> shipping.updated
- sagaCompensationFlow: 4 compensation consumers -> saga.compensate

Result: a clean run (-errors 0, any complexity) produces zero phantoms. The only remaining unconsumed producers are the deliberate errorChance() lost-message drops, which are error-gated and silent at -errors 0.