### PR TITLE
ci: build + push multi-arch container to Docker Hub on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,3 +59,41 @@ jobs:
         with:
           files: tracegen-*
           generate_release_notes: true
+
+  # Build + push the multi-arch container image to Docker Hub (immersivefusion/tracegen).
+  # Runs on the same version-tag trigger as the binaries above. Independent of `build`.
+  # Requires repo secret: DOCKERHUB_TOKEN (username is the public namespace, hardcoded below).
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: immersivefusion   # public namespace, not a secret
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker metadata (tags + labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: immersivefusion/tracegen
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - name: Build and push (linux/amd64 + arm64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Container image for TraceGen (the OTLP trace generator).
+# Multi-stage: build the static Go binary, then ship it on a distroless base.
+# Built + pushed to Docker Hub (immersivefusion/tracegen) by .github/workflows/release.yml
+# on a version-tag push. Multi-arch via buildx (TARGETOS/TARGETARCH).
+#
+# Usage on a cluster (the binary takes the same flags as the CLI):
+#   docker run --rm immersivefusion/tracegen -endpoint <collector:4317> -insecure ...
+# syntax=docker/dockerfile:1
+
+FROM golang:1.22-bookworm AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+ARG TARGETOS TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -ldflags="-s -w" -o /out/tracegen ./cmd/tracegen
+
+# distroless/static: no shell, CA certs included (for OTLP/TLS egress), runs as non-root.
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=build /out/tracegen /usr/bin/tracegen
+ENTRYPOINT ["/usr/bin/tracegen"]


### PR DESCRIPTION
Adds a Dockerfile (multi-stage Go build -> distroless/static:nonroot, CA certs for OTLP egress, runs non-root) and a `docker` job in the release workflow. On a version-tag push it builds linux/amd64 + linux/arm64 and pushes immersivefusion/tracegen:<version> + :latest, alongside the existing binary release.

Requires repo secrets: DOCKERHUB_USERNAME, DOCKERHUB_TOKEN.