### PR TITLE
fix(docker): build on golang:1.25 (go.mod requires go >= 1.25.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 #   docker run --rm immersivefusion/tracegen -endpoint <collector:4317> -insecure ...
 # syntax=docker/dockerfile:1
 
-FROM golang:1.22-bookworm AS build
+FROM golang:1.25-bookworm AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download


### PR DESCRIPTION
The golang base images pin GOTOOLCHAIN=local, so 1.22 would not auto-download the 1.25 toolchain and `go mod download` failed. CI binary builds survived only because setup-go uses GOTOOLCHAIN=auto. Match the base to go.mod.