### PR TITLE
docs(dockerhub): add Hub overview + auto-publish workflow

### DIFF
--- a/.github/workflows/dockerhub-readme.yml
+++ b/.github/workflows/dockerhub-readme.yml
@@ -1,0 +1,31 @@
+name: Docker Hub description
+
+# Publishes the Docker Hub overview + short description from DOCKERHUB.md.
+# Converge-to-source: the Hub page is never hand-edited; DOCKERHUB.md is the single source.
+# Runs on merge to main when DOCKERHUB.md changes (so the page updates immediately), and on demand.
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - DOCKERHUB.md
+      - .github/workflows/dockerhub-readme.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  description:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: immersivefusion
+          password: ${{ secrets.DOCKERHUB_TOKEN }}   # PAT with read/write; same secret as the image push
+          repository: immersivefusion/tracegen
+          short-description: "Single-binary OTLP trace generator: 28-service topology, AI agentic spans, injectable failures"
+          readme-filepath: ./DOCKERHUB.md

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -1,0 +1,56 @@
+# TraceGen
+
+**One container that emits realistic, topology-rich OpenTelemetry traces, including AI agentic spans.** No microservices to deploy, no Docker Compose with 15 containers. A single 5.7 MB image simulates a full e-commerce platform: up to 28 services, 60 pods, 40 scenario flows, and 10 injectable failure modes, with full OTel GenAI semantic conventions for LLM/agent observability.
+
+Built for testing observability platforms, load-testing trace pipelines, and showcasing distributed-system visualizations, for both traditional APM and LLM observability.
+
+## Quick start
+
+Point it at any OTLP/gRPC collector (Jaeger, Tempo, Grafana, an OTel Collector, or a commercial backend):
+
+```bash
+# Traces to a collector on your host
+docker run --rm immersivefusion/tracegen -insecure -endpoint host.docker.internal:4317
+
+# Crank up the volume and inject failures
+docker run --rm immersivefusion/tracegen -insecure -endpoint host.docker.internal:4317 -level 8 -errors 5
+```
+
+The image is multi-arch (`linux/amd64`, `linux/arm64`), distroless, and runs as non-root.
+
+## Three things to try
+
+| Goal | Command |
+| --- | --- |
+| **AI agentic traces only** (LLM/GenAI spans) | `-ai-only` |
+| **Traditional APM only** (no AI backends) | `-no-ai-backends` |
+| **Chaos** (failures + unconsumed queues) | `-errors 10 -level 8 -no-consumers` |
+
+## Flags
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `-endpoint` | `localhost:4317` | OTLP gRPC endpoint (`host:port`) |
+| `-insecure` | `false` | Plaintext gRPC (no TLS) for local/in-cluster backends |
+| `-headers` | | OTLP headers, `key=value` comma-separated (e.g. `api-key=SECRET`) |
+| `-level` | `1` | Aggressiveness 1-10 (1 = whisper, 10 = SCREAM) |
+| `-errors` | `0` | Error rate 0-10 (0 = none, 5 = normal, 10 = chaos) |
+| `-complexity` | `normal` | Topology size: `light`, `normal`, `heavy` |
+| `-ai-only` | `false` | Only run AI agentic scenarios |
+| `-no-ai-backends` | `false` | Disable LLM/AI backends (AI spans emit errors) |
+| `-no-consumers` | `false` | Publish to queues but never consume (backlog demo) |
+| `-no-logs` | `false` | Traces only, no OTel log records |
+
+## Why it exists
+
+Existing trace generators are either flat span emitters (no service topology) or full demo apps that need Docker Compose and 8 GB of RAM, and none of them generate AI agentic traces. TraceGen produces topology-rich, failure-injectable traces from a single binary, covering both traditional microservice flows and AI agentic patterns. One image proves a platform can visualize both.
+
+## Tags
+
+- `latest`, `0.6.1`, ... track the GitHub releases. Pin by digest in production/cluster use.
+
+## Source, issues, full docs
+
+[github.com/ImmersiveFusion/if-opentelemetry-tracegen](https://github.com/ImmersiveFusion/if-opentelemetry-tracegen)
+
+Apache-2.0. Built by Immersive Fusion.


### PR DESCRIPTION
The Docker Hub page showed 'No overview available'. Adds DOCKERHUB.md (the container-first overview + flags + scenarios) and a workflow that publishes it (plus the short description) to Docker Hub on merge to main and on demand. Converge-to-source: the Hub page is never hand-edited.