### PR TITLE
docs(contributing): document v-prefix release tag convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,29 @@ GOOS=windows GOARCH=amd64 go build -o tracegen.exe ./cmd/tracegen
 4. Use clear, conventional commit messages (`feat:`, `fix:`, `docs:`, …).
 5. Open the PR against `main` and describe what changed and why.
 
+## Releasing
+
+Releases are cut by pushing a version tag. The CI workflow
+([`.github/workflows/release.yml`](.github/workflows/release.yml)) builds the
+cross-platform binaries, publishes a GitHub Release, and pushes the multi-arch
+container image to Docker Hub.
+
+**Tag format: use the `v`-prefixed form, e.g. `v0.7.4`.** This is the canonical
+scheme going forward (it matches the Go ecosystem and what GoReleaser expects).
+
+```bash
+git tag v0.7.4
+git push origin v0.7.4
+```
+
+The trigger also still accepts the older bare-number form (`0.7.4`) for
+backward compatibility with historical tags, but new releases should always be
+`v`-prefixed so the Tags/Releases lists stay consistent and sort cleanly.
+
+Note: the workflow evaluates the tag trigger **at the moment the tag is
+pushed**. If a tag was pushed before a trigger fix landed on `main`, fixing the
+trigger does not retroactively run it — push a new (higher) version tag instead.
+
 ## Reporting issues
 
 Use the issue templates. For bugs, include your platform/architecture, the exact `tracegen` command and flags, and what you expected versus what happened. `-log-level debug` gives more detail.


### PR DESCRIPTION
Add a Releasing section establishing v-prefixed tags (v0.7.4) as canonical, note the trigger still accepts bare-number tags for back-compat, and warn that the workflow evaluates the tag trigger at push time (a pre-fix tag won't retroactively run -- push a higher tag). Durable fix for the mis-tagged-release failure mode.