### PR TITLE
docs(readme): clarify heavy adds 4 of the 12 AI agentic scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Flags:
 
 **Normal** (default) adds all remaining traditional services and scenarios including chaos/failure modes.
 
-**Heavy** adds all 8 AI services and 4 AI agentic scenarios (RAG Search, AI Chatbot, Content Moderation, Multi-Step Agent).
+**Heavy** adds all 8 AI services and 4 of the 12 AI agentic scenarios (RAG Search, AI Chatbot, Content Moderation, Multi-Step Agent).
 
 ### Aggressiveness Levels
 


### PR DESCRIPTION
The Complexity levels section said "4 AI agentic scenarios" while the section header and comparison table both say there are 12, reading as number-drift. Add "of the 12" so it clarifies rather than contradicts, matching the existing "20 (of 40 defined)" house style for scenario flows. Requested by Trout (MKT-SP-043, bus #1587) ahead of the Show HN.