### PR TITLE
Add CI quality gate (lint/test/format + R-LOCAL-005 guard)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# Keep the build context small. The image build needs only the Go module and
+# sources; everything below is irrelevant to it.
+
+# VCS + CI + editor
+.git
+.github
+.claude
+.idea
+.vscode
+
+# Docs-only assets (README screenshots/gifs), not needed to build
+.img
+
+# Build output
+dist/
+tracegen
+tracegen.exe
+*.exe
+
+# Test artifacts
+coverage.txt
+*.test
+*.out

--- a/.github/ISSUE_TEMPLATE/add-a-deployment.md
+++ b/.github/ISSUE_TEMPLATE/add-a-deployment.md
@@ -5,12 +5,12 @@ title: "[deployment] <your name or org>"
 labels: deployment
 ---
 
-Running TraceGen somewhere? Add it to the board. A pull request to [`WHERE-TRACEGEN-RUNS.md`](../../WHERE-TRACEGEN-RUNS.md) is the fastest path — but if you'd rather we add it, fill this in and we will.
+Running TraceGen somewhere? Add it to the board. A pull request to [`WHERE-TRACEGEN-RUNS.md`](../../WHERE-TRACEGEN-RUNS.md) is the fastest path, but if you'd rather we add it, fill this in and we will.
 
 - **Who:** <your name or org>
 - **Where it runs:** <platform + architecture, e.g. "AWS EKS, x86_64" or "a Raspberry Pi cluster">
-- **What for:** <the use case — what TraceGen is doing for you>
+- **What for:** <the use case, what TraceGen is doing for you>
 - **Flavor:** <container or binary; the image tag you run, e.g. `immersivefusion/tracegen:0.6.1`; roughly how many instances / how hard you push it>
-- **Link:** <optional but encouraged — a live URL, blog post, or repo; it's the best proof>
+- **Link:** <optional but encouraged, a live URL, blog post, or repo; it's the best proof>
 
-Keep it factual and specific — no marketing. The specifics are the merit.
+Keep it factual and specific: no marketing. The specifics are the merit.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,7 +9,7 @@ labels: enhancement
 What are you trying to do that TraceGen can't do today?
 
 **Proposed solution**
-What you'd like to see — a new flag, scenario, span shape, etc.
+What you'd like to see: a new flag, scenario, span shape, etc.
 
 **Alternatives**
 Anything you've tried or considered.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+# Quality gate on every push and PR: static analysis, formatting, tests, and
+# the house R-LOCAL-005 glyph guard. Additive to release.yml (which is unchanged).
+# Action versions are pinned.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+
+      # Fail closed on em/en dashes and arrow glyphs anywhere in the tree.
+      # ASCII only: comma/colon/parens, or -> in flow text. R-LOCAL-005.
+      - name: No em dashes or arrows (R-LOCAL-005)
+        run: |
+          if git grep -nP '[\x{2013}\x{2014}\x{2190}-\x{2194}\x{21D2}]' -- .; then
+            echo "::error::Found em/en dash or arrow glyphs. Use ASCII (comma/colon/parens, or -> ). R-LOCAL-005."
+            exit 1
+          fi
+
+      - name: gofumpt (fail on diff)
+        run: |
+          go install mvdan.cc/gofumpt@v0.7.0
+          files=$(gofumpt -l .)
+          if [ -n "$files" ]; then
+            echo "::error::gofumpt would reformat these files:"
+            echo "$files"
+            exit 1
+          fi
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v7 # v7 is required for golangci-lint v2
+        with:
+          # Must be built with a Go >= our go.mod target (1.25), else it refuses
+          # to load. Renovate keeps this current.
+          version: v2.12.2
+
+      - name: go build
+        run: go build ./...
+
+      - name: go test (race + cover)
+        run: go test -race -cover ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,11 @@ jobs:
 
       # Fail closed on em/en dashes and arrow glyphs anywhere in the tree.
       # ASCII only: comma/colon/parens, or -> in flow text. R-LOCAL-005.
+      # -I skips binary files (e.g. .img/*.gif) whose bytes can coincidentally
+      # match the glyph range.
       - name: No em dashes or arrows (R-LOCAL-005)
         run: |
-          if git grep -nP '[\x{2013}\x{2014}\x{2190}-\x{2194}\x{21D2}]' -- .; then
+          if git grep -nIP '[\x{2013}\x{2014}\x{2190}-\x{2194}\x{21D2}]' -- .; then
             echo "::error::Found em/en dash or arrow glyphs. Use ASCII (comma/colon/parens, or -> ). R-LOCAL-005."
             exit 1
           fi

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,51 @@
+# golangci-lint v2 configuration. Quality gate additive to the existing build:
+# release/build/container conventions are unchanged; this adds static analysis
+# and formatting on top. Run locally with `golangci-lint run` (and
+# `golangci-lint fmt` to apply the gofumpt formatter).
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  # errcheck, govet, ineffassign, staticcheck, and unused are enabled by default
+  # in v2; listed here for intent. revive, misspell, and gosec are added.
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - revive
+    - misspell
+    - gosec
+  settings:
+    misspell:
+      locale: US
+    revive:
+      rules:
+        # Require doc comments on every exported symbol (house standard).
+        - name: exported
+  exclusions:
+    # Keep the standard-library error-handling exclusions (e.g. unchecked
+    # Body.Close, os.Remove in cleanup paths); everything else stays strict.
+    presets:
+      - std-error-handling
+    rules:
+      # Tests: relax gosec.
+      - path: _test\.go
+        linters:
+          - gosec
+      # G404: tracegen emits SYNTHETIC telemetry; math/rand (weak PRNG) is the
+      # whole point of the tool and is not security-sensitive.
+      - linters: [gosec]
+        text: "G404"
+      # G706: the CLI logs its own -flag values back on invalid input (benign).
+      - linters: [gosec]
+        text: "G706"
+
+formatters:
+  # gofumpt is a formatter in v2: `golangci-lint run` reports diffs, and CI also
+  # runs `gofumpt -l` directly as a fail-on-diff gate.
+  enable:
+    - gofumpt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
 # Contributing to TraceGen
 
-Thanks for your interest in TraceGen — a single-binary OpenTelemetry trace generator. Bug reports, feature ideas, code, and docs are all welcome.
+Thanks for your interest in TraceGen, a single-binary OpenTelemetry trace generator. Bug reports, feature ideas, code, and docs are all welcome.
 
 ## Ways to contribute
 
-- **Report a bug** or **request a feature** — open an issue with one of the [issue templates](.github/ISSUE_TEMPLATE).
-- **Add your deployment** — running TraceGen somewhere? Add it to [`WHERE-TRACEGEN-RUNS.md`](WHERE-TRACEGEN-RUNS.md) via a pull request, or use the "Add a deployment" issue template and we'll add it for you.
-- **Send a pull request** — see below.
+- **Report a bug** or **request a feature**: open an issue with one of the [issue templates](.github/ISSUE_TEMPLATE).
+- **Add your deployment**: running TraceGen somewhere? Add it to [`WHERE-TRACEGEN-RUNS.md`](WHERE-TRACEGEN-RUNS.md) via a pull request, or use the "Add a deployment" issue template and we'll add it for you.
+- **Send a pull request**: see below.
 
 ## Building from source
 
@@ -30,7 +30,7 @@ GOOS=windows GOARCH=amd64 go build -o tracegen.exe ./cmd/tracegen
 ## Pull requests
 
 1. Fork the repo and branch from `main`.
-2. Keep changes focused — one logical change per PR.
+2. Keep changes focused: one logical change per PR.
 3. Run `go build ./...` and `go vet ./...` before pushing.
 4. Use clear, conventional commit messages (`feat:`, `fix:`, `docs:`, …).
 5. Open the PR against `main` and describe what changed and why.
@@ -56,7 +56,7 @@ backward compatibility with historical tags, but new releases should always be
 
 Note: the workflow evaluates the tag trigger **at the moment the tag is
 pushed**. If a tag was pushed before a trigger fix landed on `main`, fixing the
-trigger does not retroactively run it — push a new (higher) version tag instead.
+trigger does not retroactively run it. Push a new (higher) version tag instead.
 
 ## Reporting issues
 

--- a/README.md
+++ b/README.md
@@ -36,15 +36,15 @@ tracegen -endpoint your-otlp-endpoint:443
 
 > **See it in 3D** - Send traces to [IAPM](https://immersivefusion.com) (`tracegen -endpoint otlp.iapm.app:443 -headers "api-key=YOUR_KEY"`) to explore them as a 3D force-directed graph, drill into conventional trace waterfalls for detailed analysis, and get AI-assisted insights from [Tessa](https://immersivefusion.com). For a ready-made example without any setup, try the [OpenTelemetry Chaos Simulator](https://github.com/ImmersiveFusion/if-opentelemetry-chaos-simulator-sample) at [demo.iapm.app](https://demo.iapm.app) - a fully interactive sandbox with visual failure injection.
 
-## Live demo grids — see it running
+## Live demo grids: see it running
 
 ![The seven demo grids streaming live, in motion](.img/tracegen.gif)
 
-Seven always-on demo grids stream live OpenTelemetry traces into IAPM's 3D player right now — a clean baseline, an AI-native app, a blended environment, phantom-service detection, an AI-outage, and a full incident. Each grid is this container, deployed declaratively via GitOps (Argo CD) in the Immersive Fusion cloud — multi-arch and distroless, one matrix row per grid, shipping to `otlp.iapm.app:443`.
+Seven always-on demo grids stream live OpenTelemetry traces into IAPM's 3D player right now: a clean baseline, an AI-native app, a blended environment, phantom-service detection, an AI-outage, and a full incident. Each grid is this container, deployed declaratively via GitOps (Argo CD) in the Immersive Fusion cloud, multi-arch and distroless, one matrix row per grid, shipping to `otlp.iapm.app:443`.
 
-**See them in 3D:** the full experience is the **IAPM 3D client** — install it and open a grid to walk the live traces. On mobile or can't install right now? **IAPM Web** runs the same grids in your browser at [portal.iapm.app](https://portal.iapm.app).
+**See them in 3D:** the full experience is the **IAPM 3D client**: install it and open a grid to walk the live traces. On mobile or can't install right now? **IAPM Web** runs the same grids in your browser at [portal.iapm.app](https://portal.iapm.app).
 
-**[Where else does TraceGen run? →](WHERE-TRACEGEN-RUNS.md)** — a community board of deployments. Add yours.
+**[Where else does TraceGen run?](WHERE-TRACEGEN-RUNS.md)**: a community board of deployments. Add yours.
 
 ## Features
 

--- a/WHERE-TRACEGEN-RUNS.md
+++ b/WHERE-TRACEGEN-RUNS.md
@@ -1,6 +1,6 @@
 # Where TraceGen Runs
 
-**One container. 5.7 MB. It runs anywhere — and this is the board of where it actually does.**
+**One container. 5.7 MB. It runs anywhere, and this is the board of where it actually does.**
 
 TraceGen ships as a single distroless, multi-arch image (`linux/amd64` + `linux/arm64`), no Compose, no multi-gigabyte RAM footprint, no microservices to stand up:
 
@@ -9,44 +9,44 @@ TraceGen ships as a single distroless, multi-arch image (`linux/amd64` + `linux/
 docker run --rm immersivefusion/tracegen -insecure -endpoint host.docker.internal:4317
 ```
 
-That portability is the whole point — the same image runs on a laptop, a CI runner, a cloud cluster, or a fanless desktop in someone's office. Below is where it's running for real. If you're running it somewhere, add yours — see [Add your deployment](#add-your-deployment).
+That portability is the whole point: the same image runs on a laptop, a CI runner, a cloud cluster, or a fanless desktop in someone's office. Below is where it's running for real. If you're running it somewhere, add yours, see [Add your deployment](#add-your-deployment).
 
 ---
 
 ## The deployments
 
-### Immersive Fusion — live public demo grids
+### Immersive Fusion: live public demo grids
 
-- **Where it runs:** the **Immersive Fusion cloud** — seven always-on workloads on Kubernetes, deployments managed declaratively via GitOps (Argo CD).
-- **What for:** **seven always-on public demo grids** — each one a separate TraceGen deployment streaming live OpenTelemetry traces into [IAPM](https://immersivefusion.com)'s 3D player, so anyone can open it and watch *real data moving* instead of a canned recording. Each grid is tuned to tell one story:
-  - **traditional-clean** — a healthy e-commerce platform: the calm, mostly-green reference graph.
-  - **ai-flagship** — an AI-native application, observed: a RAG pipeline, an AI chatbot, content moderation, and a multi-step agent emitting full OTel GenAI spans.
-  - **blended** — the real world, traditional + AI together: classic microservices and AI services sharing one trace graph, with real error traffic.
-  - **phantom** — services you didn't know you had: dead consumers, so the platform infers the missing ("phantom") services from the topology.
-  - **ai-clean** — AI on a calm day: the agentic topology at a low error rate.
-  - **traditional** — when the AI tier goes down: the full traditional platform with its AI backends erroring (rate limits, timeouts).
-  - **incident** — everything is on fire: maximum errors plus dead consumers, the root-cause / incident-response demo.
-- **Flavor:** the distroless container (`immersivefusion/tracegen`, pinned by digest in GitOps — the same pin-by-digest we'd ask of you below), one Kubernetes Deployment per grid, each shipping to `otlp.iapm.app:443`. The three densest grids (ai-clean, traditional, incident) run at a low `-level` floor — full topology, gentle trace rate — so the 3D player stays smooth while all seven run side by side.
-- **The point:** the whole image is 5.7 MB and each grid sips a few dozen megabytes of RAM — light enough that the entire fleet would cheerfully run off a Mac mini in a broom closet. (It doesn't — it runs in the Immersive Fusion cloud — but it absolutely could.) **See them live — in 3D.** The way to experience this is the **IAPM 3D client**: install it, open a demo grid, and walk the live traces in three dimensions — fly the topology, drill into a failing span, lean on the AI assistant. That's the real thing. On a phone, or can't install right now? **IAPM Web** runs the same grids in your browser at [portal.iapm.app](https://portal.iapm.app) — sign in and open a grid. Don't want to install or sign in at all? **Watch the grids live on Twitch** at [twitch.tv/immersivefusion](https://www.twitch.tv/immersivefusion) — the 3D player, streamed in real time, zero friction.
+- **Where it runs:** the **Immersive Fusion cloud**: seven always-on workloads on Kubernetes, deployments managed declaratively via GitOps (Argo CD).
+- **What for:** **seven always-on public demo grids**, each one a separate TraceGen deployment streaming live OpenTelemetry traces into [IAPM](https://immersivefusion.com)'s 3D player, so anyone can open it and watch *real data moving* instead of a canned recording. Each grid is tuned to tell one story:
+  - **traditional-clean**, a healthy e-commerce platform: the calm, mostly-green reference graph.
+  - **ai-flagship**, an AI-native application, observed: a RAG pipeline, an AI chatbot, content moderation, and a multi-step agent emitting full OTel GenAI spans.
+  - **blended**, the real world, traditional + AI together: classic microservices and AI services sharing one trace graph, with real error traffic.
+  - **phantom**, services you didn't know you had: dead consumers, so the platform infers the missing ("phantom") services from the topology.
+  - **ai-clean**, AI on a calm day: the agentic topology at a low error rate.
+  - **traditional**, when the AI tier goes down: the full traditional platform with its AI backends erroring (rate limits, timeouts).
+  - **incident**, everything is on fire: maximum errors plus dead consumers, the root-cause / incident-response demo.
+- **Flavor:** the distroless container (`immersivefusion/tracegen`, pinned by digest in GitOps, the same pin-by-digest we'd ask of you below), one Kubernetes Deployment per grid, each shipping to `otlp.iapm.app:443`. The three densest grids (ai-clean, traditional, incident) run at a low `-level` floor (full topology, gentle trace rate) so the 3D player stays smooth while all seven run side by side.
+- **The point:** the whole image is 5.7 MB and each grid sips a few dozen megabytes of RAM, light enough that the entire fleet would cheerfully run off a Mac mini in a broom closet. (It doesn't, it runs in the Immersive Fusion cloud, but it absolutely could.) **See them live, in 3D.** The way to experience this is the **IAPM 3D client**: install it, open a demo grid, and walk the live traces in three dimensions: fly the topology, drill into a failing span, lean on the AI assistant. That's the real thing. On a phone, or can't install right now? **IAPM Web** runs the same grids in your browser at [portal.iapm.app](https://portal.iapm.app), sign in and open a grid. Don't want to install or sign in at all? **Watch the grids live on Twitch** at [twitch.tv/immersivefusion](https://www.twitch.tv/immersivefusion): the 3D player, streamed in real time, zero friction.
 
 ---
 
 ## Add your deployment
 
-Running TraceGen somewhere — a load test, a CI pipeline, a teaching lab, a backend bake-off, a homelab, a demo of your own? **List your shit too.** This board is earned, not bought: the only entry fee is that you actually run it.
+Running TraceGen somewhere: a load test, a CI pipeline, a teaching lab, a backend bake-off, a homelab, a demo of your own? **List your shit too.** This board is earned, not bought: the only entry fee is that you actually run it.
 
 Open a pull request at [github.com/ImmersiveFusion/if-opentelemetry-tracegen](https://github.com/ImmersiveFusion/if-opentelemetry-tracegen) adding a block under [The deployments](#the-deployments) using this template:
 
 ```markdown
-### <Your name or org> — <one-line what>
+### <Your name or org>: <one-line what>
 
 - **Where it runs:** <platform + architecture, e.g. "AWS EKS, x86_64" or "a Raspberry Pi cluster">
-- **What for:** <the use case — what TraceGen is doing for you>
+- **What for:** <the use case, what TraceGen is doing for you>
 - **Flavor:** <container or binary; the image tag you run, e.g. immersivefusion/tracegen:0.6.1; roughly how many instances / how hard you push it>
-- **Link:** <optional but encouraged — a live URL, a blog post, or a repo; it's the best proof>
+- **Link:** <optional but encouraged, a live URL, a blog post, or a repo; it's the best proof>
 ```
 
-Keep it factual and specific — the specifics are the merit. No marketing, no logos-for-sale; just where the image lands and what it does there. A maintainer will review and merge; entries that name a platform, a use case, and a version (or a link) move fastest.
+Keep it factual and specific: the specifics are the merit. No marketing, no logos-for-sale; just where the image lands and what it does there. A maintainer will review and merge; entries that name a platform, a use case, and a version (or a link) move fastest.
 
 Prefer not to write the PR yourself? [Open an issue](https://github.com/ImmersiveFusion/if-opentelemetry-tracegen/issues/new) with the same details and we'll add it.
 

--- a/cmd/tracegen/helpers.go
+++ b/cmd/tracegen/helpers.go
@@ -186,8 +186,10 @@ func randomOrderID() string {
 }
 
 func randomSearchTerm() string {
-	terms := []string{"widget", "dashboard", "monitor", "alert rules", "trace analysis", "service health",
-		"wireless keyboard", "USB-C hub", "laptop stand", "noise cancelling headphones", "ergonomic mouse"}
+	terms := []string{
+		"widget", "dashboard", "monitor", "alert rules", "trace analysis", "service health",
+		"wireless keyboard", "USB-C hub", "laptop stand", "noise canceling headphones", "ergonomic mouse",
+	}
 	return terms[rand.Intn(len(terms))]
 }
 
@@ -200,7 +202,7 @@ func randomHex(n int) string {
 	if _, err := cryptorand.Read(b); err != nil {
 		// Fallback to math/rand if crypto/rand fails
 		for i := range b {
-			b[i] = byte(rand.Intn(256))
+			b[i] = byte(rand.Intn(256)) //nolint:gosec // G115: rand.Intn(256) is always in [0,255]
 		}
 	}
 	return hex.EncodeToString(b)[:n]
@@ -216,7 +218,7 @@ type modelInfo struct {
 	peer     string // peer.service value
 }
 
-// Chat/completion models — mix of providers and tiers
+// Chat/completion models: mix of providers and tiers
 var chatModels = []modelInfo{
 	{"gpt-5.4", "openai", "https://api.openai.com/v1/chat/completions", "openai-api"},
 	{"gpt-5.4-mini", "openai", "https://api.openai.com/v1/chat/completions", "openai-api"},
@@ -243,9 +245,9 @@ var embeddingModels = []modelInfo{
 	{"Cohere-rerank-v4.0-pro", "cohere", "https://api.cohere.com/v2/embed", "cohere-api"},
 }
 
-func randomChatModel() modelInfo       { return chatModels[rand.Intn(len(chatModels))] }
-func randomLightChatModel() modelInfo  { return lightChatModels[rand.Intn(len(lightChatModels))] }
-func randomEmbeddingModel() modelInfo  { return embeddingModels[rand.Intn(len(embeddingModels))] }
+func randomChatModel() modelInfo      { return chatModels[rand.Intn(len(chatModels))] }
+func randomLightChatModel() modelInfo { return lightChatModels[rand.Intn(len(lightChatModels))] }
+func randomEmbeddingModel() modelInfo { return embeddingModels[rand.Intn(len(embeddingModels))] }
 
 // ─── GenAI Helper Functions ───────────────────────────────────────────────────
 // These produce spans matching Microsoft Semantic Kernel / Agent Framework OTel

--- a/cmd/tracegen/main.go
+++ b/cmd/tracegen/main.go
@@ -16,22 +16,25 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	logapi "go.opentelemetry.io/otel/log"
-	"go.opentelemetry.io/otel/sdk/resource"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
+	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-var tracerPool = map[string][]trace.Tracer{}
-var loggerPool = map[string][]logapi.Logger{}
-var providers []*sdktrace.TracerProvider
-var logProviders []*sdklog.LoggerProvider
+var (
+	tracerPool   = map[string][]trace.Tracer{}
+	loggerPool   = map[string][]logapi.Logger{}
+	providers    []*sdktrace.TracerProvider
+	logProviders []*sdklog.LoggerProvider
+)
 
 // noopTracer is returned for services not in the current complexity tier
-var noopTracer = trace.NewNoopTracerProvider().Tracer("")
+var noopTracer = noop.NewTracerProvider().Tracer("")
 
 // tracer returns a random instance's tracer for the given service (multi-pod realism).
 // Returns a noop tracer if the service is not in the current complexity tier.
@@ -160,25 +163,25 @@ var levels = map[int]levelConfig{
 	10: {10, 3, 4, "SCREAM (~350/s)"},
 }
 
-// Global error multiplier — set by -errors flag, used by errorChance()
+// Global error multiplier: set by -errors flag, used by errorChance()
 var errorMultiplier float64
 
-// consumersEnabled — when false, all async consumers are dead (queue messages pile up)
+// consumersEnabled: when false, all async consumers are dead (queue messages pile up)
 var consumersEnabled bool
 
-// insecureMode — when true, use plaintext gRPC (no TLS) for local backends
+// insecureMode: when true, use plaintext gRPC (no TLS) for local backends
 var insecureMode bool
 
-// noAIBackends — when true, AI services are excluded (AI spans emit errors)
+// noAIBackends: when true, AI services are excluded (AI spans emit errors)
 var noAIBackends bool
 
-// aiOnly — when true, only AI agentic scenarios are run
+// aiOnly: when true, only AI agentic scenarios are run
 var aiOnly bool
 
-// complexity — controls how many services/pods/scenarios are active
+// complexity: controls how many services/pods/scenarios are active
 var complexity string // "light", "normal", "heavy"
 
-// logsDisabled — when true, no OTel log records are emitted
+// logsDisabled: when true, no OTel log records are emitted
 var logsDisabled bool
 
 // errorChance scales a base error probability by the global error multiplier.
@@ -187,12 +190,12 @@ func errorChance(baseRate float64) bool {
 	return rand.Float64() < baseRate*errorMultiplier
 }
 
-// Console verbosity levels — controls ONLY the periodic "traces sent" heartbeat.
+// Console verbosity levels: controls ONLY the periodic "traces sent" heartbeat.
 // Distinct from the OTel log records the generator emits. The startup banner
 // ("what it's doing") and genuine errors (stderr) always surface, at any level.
 const (
 	logSilent = iota // banner + errors only, no heartbeat
-	logError         // errors only — suppresses heartbeat (the sane container default)
+	logError         // errors only: suppresses heartbeat (the sane container default)
 	logInfo          // banner + periodic heartbeat (CLI default, current behavior)
 	logDebug         // reserved for future verbose diagnostics
 )
@@ -219,12 +222,12 @@ func resolveLogLevel(flagVal string, quiet bool) int {
 	case "debug":
 		return logDebug
 	default:
-		log.Fatalf("invalid -log-level %q — must be silent, error, info, or debug", v)
+		log.Fatalf("invalid -log-level %q, must be silent, error, info, or debug", v)
 		return logInfo
 	}
 }
 
-// infof / infoln write to stdout only at info level or above — suppressed by
+// infof writes to stdout only at info level or above: suppressed by
 // -quiet, -log-level=error, and -log-level=silent.
 func infof(format string, a ...any) {
 	if logLevel >= logInfo {
@@ -232,14 +235,8 @@ func infof(format string, a ...any) {
 	}
 }
 
-func infoln(a ...any) {
-	if logLevel >= logInfo {
-		fmt.Println(a...)
-	}
-}
-
 // bannerf / bannerln write the startup "what it's doing" intro to stdout
-// regardless of log level — even under -quiet, -log-level=error, or =silent.
+// regardless of log level, even under -quiet, -log-level=error, or =silent.
 // The banner is operator orientation, not chatter, so it is never suppressed.
 func bannerf(format string, a ...any) {
 	fmt.Printf(format, a...)
@@ -249,7 +246,7 @@ func bannerln(a ...any) {
 	fmt.Println(a...)
 }
 
-// errorf writes to stderr regardless of log level — errors are always shown,
+// errorf writes to stderr regardless of log level: errors are always shown,
 // even under -log-level=silent.
 func errorf(format string, a ...any) {
 	fmt.Fprintf(os.Stderr, format, a...)
@@ -267,7 +264,7 @@ func main() {
 	complexityFlag := flag.String("complexity", "normal", "topology complexity: light, normal, heavy")
 	noLogsFlag := flag.Bool("no-logs", false, "disable OTel log record emission (traces only)")
 	logLevelFlag := flag.String("log-level", "", "console verbosity: silent, error, info, debug (default info; env TRACEGEN_LOG_LEVEL)")
-	quietFlag := flag.Bool("quiet", false, "errors only — suppress the periodic 'traces sent' heartbeat (alias for -log-level=error); the startup banner and errors always print")
+	quietFlag := flag.Bool("quiet", false, "errors only: suppress the periodic 'traces sent' heartbeat (alias for -log-level=error); the startup banner and errors always print")
 	flag.Parse()
 	logLevel = resolveLogLevel(*logLevelFlag, *quietFlag)
 	consumersEnabled = !*noConsumers
@@ -277,7 +274,7 @@ func main() {
 	complexity = *complexityFlag
 	logsDisabled = *noLogsFlag
 	if complexity != "light" && complexity != "normal" && complexity != "heavy" {
-		log.Fatalf("invalid complexity %q — must be light, normal, or heavy", complexity)
+		log.Fatalf("invalid complexity %q, must be light, normal, or heavy", complexity)
 	}
 
 	endpoint := *endpointFlag
@@ -290,17 +287,17 @@ func main() {
 
 	cfg, ok := levels[*level]
 	if !ok {
-		log.Fatalf("invalid level %d — must be 1-10", *level)
+		log.Fatalf("invalid level %d, must be 1-10", *level)
 	}
 	if *errors < 0 || *errors > 10 {
-		log.Fatalf("invalid errors %d — must be 0-10", *errors)
+		log.Fatalf("invalid errors %d, must be 0-10", *errors)
 	}
 	errorMultiplier = float64(*errors) / 5.0 // 0=0x, 5=1x, 10=2x
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 
-	// Service definitions with replica ranges — pods are generated at startup
+	// Service definitions with replica ranges: pods are generated at startup
 	// tier: "light" = core backbone, "normal" = full traditional, "heavy" = includes AI
 	type serviceSpec struct {
 		name    string // service name
@@ -308,11 +305,11 @@ func main() {
 		hash    string // deployment hash (6 hex chars)
 		minPods int    // minimum replicas
 		maxPods int    // maximum replicas
-		isAI    bool   // AI service — excluded when -no-ai-backends
+		isAI    bool   // AI service: excluded when -no-ai-backends
 		tier    string // minimum complexity tier to include this service
 	}
 	services := []serviceSpec{
-		// Core backbone (light) — 10 services
+		// Core backbone (light): 10 services
 		{"web-frontend", "web-frontend", "d7b48c", 2, 4, false, "light"},
 		{"api-gateway", "api-gateway", "e5a21b", 3, 6, false, "light"},
 		{"order-service", "order-svc", "f3c91a", 2, 5, false, "light"},
@@ -323,7 +320,7 @@ func main() {
 		{"auth-service", "auth-svc", "b47e2f", 3, 5, false, "light"},
 		{"product-service", "product-svc", "e85c6f", 3, 5, false, "light"},
 		{"cart-service", "cart-svc", "d72b5e", 2, 4, false, "light"},
-		// Extended traditional (normal) — adds 10 more
+		// Extended traditional (normal): adds 10 more
 		{"notification-service", "notif-svc", "c59f2a", 2, 4, false, "normal"},
 		{"search-service", "search-svc", "f85c3d", 2, 4, false, "normal"},
 		{"scheduler-service", "scheduler-svc", "a93d1e", 1, 1, false, "normal"},
@@ -334,7 +331,7 @@ func main() {
 		{"tax-service", "tax-svc", "c39a1d", 1, 2, false, "normal"},
 		{"analytics-service", "analytics-svc", "d41b2e", 3, 5, false, "normal"},
 		{"config-service", "config-svc", "e52c3f", 1, 2, false, "normal"},
-		// AI services (heavy) — adds 8 more
+		// AI services (heavy): adds 8 more
 		{"llm-gateway", "llm-gw", "a23b4c", 2, 5, true, "heavy"},
 		{"embedding-service", "embed-svc", "b34c5d", 2, 4, true, "heavy"},
 		{"vector-db-service", "vecdb-svc", "c45d6e", 2, 3, true, "heavy"},
@@ -411,10 +408,10 @@ func main() {
 	}
 	defer func() {
 		for _, tp := range providers {
-			tp.Shutdown(context.Background())
+			_ = tp.Shutdown(context.Background())
 		}
 		for _, lp := range logProviders {
-			lp.Shutdown(context.Background())
+			_ = lp.Shutdown(context.Background())
 		}
 	}()
 
@@ -429,7 +426,7 @@ func main() {
 		tier     string // minimum complexity tier: "light", "normal", "heavy"
 	}
 	allScenarios := []namedScenario{
-		// Core scenarios (light) — clean demo flows
+		// Core scenarios (light): clean demo flows
 		{"Create Order", createOrderFlow, false, "traditional", "light"},
 		{"Search & Browse", searchAndBrowseFlow, false, "traditional", "light"},
 		{"User Login", userLoginFlow, false, "traditional", "light"},

--- a/cmd/tracegen/scenarios.go
+++ b/cmd/tracegen/scenarios.go
@@ -114,14 +114,14 @@ func createOrderFlow(ctx context.Context) {
 	publish.End()
 	order.End()
 
-	// Queue delivery delay — message sits in broker before consumer picks up
+	// Queue delivery delay: message sits in broker before consumer picks up
 	sleep(50, 300)
 
 	if !consumersEnabled {
 		return // messages pile up, no consumers running
 	}
 
-	// 5% chance: message lost — payment consumer never fires
+	// 5% chance: message lost, payment consumer never fires
 	if errorChance(0.05) {
 		return
 	}
@@ -172,7 +172,7 @@ func createOrderFlow(ctx context.Context) {
 	// Queue delivery delay
 	sleep(30, 150)
 
-	// 5% chance: message lost — inventory consumer never fires
+	// 5% chance: message lost, inventory consumer never fires
 	if errorChance(0.05) {
 		return
 	}
@@ -203,7 +203,7 @@ func createOrderFlow(ctx context.Context) {
 	// Queue delivery delay
 	sleep(20, 100)
 
-	// 5% chance: message lost — notification consumer never fires
+	// 5% chance: message lost, notification consumer never fires
 	if errorChance(0.05) {
 		return
 	}
@@ -379,7 +379,7 @@ func userLoginFlow(ctx context.Context) {
 	session.End()
 }
 
-// Payment failure flow — Stripe returns 402
+// Payment failure flow: Stripe returns 402
 func failedPaymentFlow(ctx context.Context) {
 	ctx, ui := tracer("web-frontend").Start(ctx, "PlaceOrder",
 		trace.WithSpanKind(trace.SpanKindClient),
@@ -474,7 +474,7 @@ func failedPaymentFlow(ctx context.Context) {
 	notify.End()
 }
 
-// Bulk notification flow — admin triggers digest from UI
+// Bulk notification flow: admin triggers digest from UI
 func bulkNotificationFlow(ctx context.Context) {
 	ctx, ui := tracer("web-frontend").Start(ctx, "TriggerDigest",
 		trace.WithSpanKind(trace.SpanKindClient),
@@ -565,7 +565,7 @@ func bulkNotificationFlow(ctx context.Context) {
 	}
 }
 
-// Health check flow — lightweight, high-frequency pings across services
+// Health check flow: lightweight, high-frequency pings across services
 func healthCheckFlow(ctx context.Context) {
 	ctx, ui := tracer("web-frontend").Start(ctx, "HealthDashboard",
 		trace.WithSpanKind(trace.SpanKindClient),
@@ -626,7 +626,7 @@ func healthCheckFlow(ctx context.Context) {
 	}
 }
 
-// Inventory sync flow — admin triggers from UI
+// Inventory sync flow: admin triggers from UI
 func inventorySyncFlow(ctx context.Context) {
 	ctx, ui := tracer("web-frontend").Start(ctx, "TriggerInventorySync",
 		trace.WithSpanKind(trace.SpanKindClient),
@@ -708,7 +708,7 @@ func inventorySyncFlow(ctx context.Context) {
 	reindex.End()
 }
 
-// Scheduled report — scheduler-service is the root, no UI or gateway entry point.
+// Scheduled report: scheduler-service is the root, no UI or gateway entry point.
 // Creates a long chain: scheduler -> order -> inventory -> cache -> notification
 func scheduledReportFlow(ctx context.Context) {
 	ctx, scheduler := tracer("scheduler-service").Start(ctx, "CronJob: DailyReport",
@@ -722,7 +722,7 @@ func scheduledReportFlow(ctx context.Context) {
 	defer scheduler.End()
 	sleep(5, 15)
 
-	// Auth check — scheduler authenticates via service account
+	// Auth check: scheduler authenticates via service account
 	_, auth := tracer("auth-service").Start(ctx, "ValidateServiceAccount",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
@@ -834,7 +834,7 @@ func scheduledReportFlow(ctx context.Context) {
 	notify.End()
 }
 
-// Stripe webhook — external callback entering at payment-service directly (no gateway).
+// Stripe webhook: external callback entering at payment-service directly (no gateway).
 // payment-service -> auth-service (verify sig) -> order-service -> cache -> notification
 func stripeWebhookFlow(ctx context.Context) {
 	ctx, webhook := tracer("payment-service").Start(ctx, "POST /webhooks/stripe",
@@ -896,7 +896,7 @@ func stripeWebhookFlow(ctx context.Context) {
 	dbUpdate.End()
 	orderUpdate.End()
 
-	// Cache invalidation — diamond dependency (both order-service and payment-service hit cache)
+	// Cache invalidation: diamond dependency (both order-service and payment-service hit cache)
 	_, cacheInval := tracer("cache-service").Start(ctx, "Redis DEL order-cache",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
@@ -942,7 +942,7 @@ func stripeWebhookFlow(ctx context.Context) {
 	notify.End()
 }
 
-// Recommendation flow — scatter-gather / bowtie pattern.
+// Recommendation flow: scatter-gather / bowtie pattern.
 // web-frontend -> api-gateway -> recommendation-service -> fan-out to search+inventory+user -> fan-in -> cache
 func recommendationFlow(ctx context.Context) {
 	ctx, ui := tracer("web-frontend").Start(ctx, "GetRecommendations",
@@ -980,7 +980,7 @@ func recommendationFlow(ctx context.Context) {
 	sleep(2, 8)
 	auth.End()
 
-	// Recommendation engine — the bowtie center
+	// Recommendation engine: the bowtie center
 	ctx2, recEngine := tracer("recommendation-service").Start(ctx, "ComputeRecommendations",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
@@ -1092,7 +1092,7 @@ func addToCartFlow(ctx context.Context) {
 	defer gateway.End()
 	sleep(3, 10)
 
-	// Feature flag check — show bundled recommendations?
+	// Feature flag check: show bundled recommendations?
 	_, flag := tracer("config-service").Start(ctx, "GetFeatureFlag",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
@@ -1206,7 +1206,7 @@ func addToCartFlow(ctx context.Context) {
 	analyticsConsumer.End()
 }
 
-// Full checkout flow — THE monster chain touching nearly every service.
+// Full checkout flow: THE monster chain touching nearly every service.
 // web -> gw -> auth -> cart -> product -> tax+shipping(parallel) -> order -> fraud -> payment -> stripe
 // -> inventory -> shipping(label) -> cache -> analytics -> [queue] -> notification -> email
 func fullCheckoutFlow(ctx context.Context) {
@@ -1539,7 +1539,7 @@ func fullCheckoutFlow(ctx context.Context) {
 	notify.End()
 }
 
-// Shipping update — carrier webhook enters at shipping-service directly (no UI/gateway).
+// Shipping update: carrier webhook enters at shipping-service directly (no UI/gateway).
 // shipping -> auth -> order -> cache -> [queue] -> notification -> email -> analytics
 func shippingUpdateFlow(ctx context.Context) {
 	shippingStatus := []string{"in_transit", "out_for_delivery", "delivered"}[rand.Intn(3)]
@@ -1672,7 +1672,7 @@ func shippingUpdateFlow(ctx context.Context) {
 	}
 }
 
-// Saga compensation — payment fails after order+inventory committed, triggering reverse compensations.
+// Saga compensation: payment fails after order+inventory committed, triggering reverse compensations.
 // Forward: web -> gw -> auth -> order -> inventory -> fraud -> payment (3 retries, all fail)
 // Reverse: saga.compensate -> parallel [cancel order, release inventory, void shipping, notify+email]
 func sagaCompensationFlow(ctx context.Context) {
@@ -1711,7 +1711,7 @@ func sagaCompensationFlow(ctx context.Context) {
 
 	orderID := randomOrderID()
 
-	// Create order (succeeds — will need compensation)
+	// Create order (succeeds, will need compensation)
 	ctx2, order := tracer("order-service").Start(ctx, "CreateOrder",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
@@ -1734,7 +1734,7 @@ func sagaCompensationFlow(ctx context.Context) {
 	dbInsert.End()
 	order.End()
 
-	// Reserve inventory (succeeds — will need compensation)
+	// Reserve inventory (succeeds, will need compensation)
 	_, reserve := tracer("inventory-service").Start(ctx, "ReserveStock",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
@@ -1757,7 +1757,7 @@ func sagaCompensationFlow(ctx context.Context) {
 	sleep(15, 40)
 	fraud.End()
 
-	// Payment — Stripe call with 3 retries, all fail
+	// Payment: Stripe call with 3 retries, all fail
 	ctx3, payment := tracer("payment-service").Start(ctx, "ProcessPayment",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
@@ -1888,7 +1888,7 @@ func sagaCompensationFlow(ctx context.Context) {
 			trace.WithAttributes(
 				attribute.String("messaging.system", "rabbitmq"),
 				attribute.String("messaging.destination", "saga.compensate"),
-				attribute.String("notification.type", "order_cancelled"),
+				attribute.String("notification.type", "order_canceled"),
 				attribute.String("order.id", orderID),
 			),
 		)
@@ -1897,7 +1897,7 @@ func sagaCompensationFlow(ctx context.Context) {
 			trace.WithSpanKind(trace.SpanKindClient),
 			trace.WithAttributes(
 				attribute.String("peer.service", "sendgrid"),
-				attribute.String("email.template", "order_cancelled"),
+				attribute.String("email.template", "order_canceled"),
 			),
 		)
 		sleep(25, 80)
@@ -1940,7 +1940,7 @@ func sagaCompensationFlow(ctx context.Context) {
 	}
 }
 
-// Timeout cascade — search-service is slow, gateway times out, frontend retries with cache fallback.
+// Timeout cascade: search-service is slow, gateway times out, frontend retries with cache fallback.
 // Attempt 1: web -> gw -> search (SLOW, timeout) -> gw 504
 // Attempt 2: web -> gw -> config (check feature flag) -> cache (stale hit) -> analytics
 func timeoutCascadeFlow(ctx context.Context) {
@@ -1956,7 +1956,7 @@ func timeoutCascadeFlow(ctx context.Context) {
 	defer ui.End()
 	sleep(2, 5)
 
-	// First attempt — gateway times out
+	// First attempt: gateway times out
 	_, gw1 := tracer("api-gateway").Start(ctx, "GET /api/v2/search (attempt 1/2)",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
@@ -1968,7 +1968,7 @@ func timeoutCascadeFlow(ctx context.Context) {
 	)
 	sleep(5, 10)
 
-	// Search is slow — ES garbage collection or shard relocation
+	// Search is slow: ES garbage collection or shard relocation
 	_, slowSearch := tracer("search-service").Start(ctx, "Elasticsearch Query (slow)",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
@@ -1991,7 +1991,7 @@ func timeoutCascadeFlow(ctx context.Context) {
 
 	sleep(50, 200) // client retry delay
 
-	// Second attempt — circuit breaker open, serves stale cache
+	// Second attempt: circuit breaker open, serves stale cache
 	_, gw2 := tracer("api-gateway").Start(ctx, "GET /api/v2/search (attempt 2/2)",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
@@ -2005,7 +2005,7 @@ func timeoutCascadeFlow(ctx context.Context) {
 	)
 	sleep(3, 8)
 
-	// Config check — stale cache fallback enabled?
+	// Config check: stale cache fallback enabled?
 	_, configCheck := tracer("config-service").Start(ctx, "GetFeatureFlag search.stale_cache_fallback",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(

--- a/cmd/tracegen/scenarios_ai.go
+++ b/cmd/tracegen/scenarios_ai.go
@@ -227,7 +227,7 @@ func aiChatbotFlow(ctx context.Context) {
 	defer agent.End()
 	sleep(5, 15)
 
-	// Planning step — LLM decides which tools to call
+	// Planning step: LLM decides which tools to call
 	chatModel := randomChatModel()
 	planInputTokens := 200 + rand.Intn(600)
 	planOutputTokens := 50 + rand.Intn(150)
@@ -595,7 +595,7 @@ func multiStepAgentFlow(ctx context.Context) {
 		}
 		plan.End()
 
-		// Act step — execute selected tool
+		// Act step: execute selected tool
 		tool := toolRegistry[rand.Intn(len(toolRegistry))]
 		toolCtx, toolExec := toolSpan(iterCtx, tool.name, tool.desc)
 		sleep(10, 30)
@@ -656,7 +656,7 @@ func multiStepAgentFlow(ctx context.Context) {
 		}
 		toolExec.End()
 
-		// Reflect step — LLM evaluates tool results and decides next step
+		// Reflect step: LLM evaluates tool results and decides next step
 		reflectInput := 300 + i*200 + rand.Intn(400)
 		reflectOutput := 80 + rand.Intn(120)
 		totalInputTokens += reflectInput

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits"
+  ],
+  "labels": ["dependencies"],
+  "prConcurrentLimit": 5,
+  "packageRules": [
+    {
+      "description": "Group Go module updates into one PR.",
+      "matchManagers": ["gomod"],
+      "groupName": "go modules"
+    },
+    {
+      "description": "Group GitHub Actions updates into one PR.",
+      "matchManagers": ["github-actions"],
+      "groupName": "github actions"
+    }
+  ]
+}


### PR DESCRIPTION
tracegen previously had only `release.yml`. This adds the same quality CI that sos-beacon uses, and brings the tree into compliance so the gate is green.

## Added
- **`.github/workflows/ci.yml`** on push/PR: gofumpt (fail on diff), `go vet`, golangci-lint, `go build`, `go test -race -cover`, and the house **R-LOCAL-005 glyph guard** (fail-closed on em/en dashes + arrows). Actions pinned. golangci-lint-action **v7** with golangci-lint **v2.12.2** (v6 / older pins are incompatible with a Go 1.25 target, learned the hard way).
- **`.golangci.yml`** (govet, staticcheck, errcheck, ineffassign, unused, gofumpt, revive, misspell, gosec).
- **`.dockerignore`** and **`renovate.json`**.

## Compliance fixes (to pass the new gate)
- **Glyphs:** pruned all 87 R-LOCAL-005 em dashes across docs + Go comments/strings, replaced with context-appropriate ASCII (colon/comma/parens, no bare hyphens).
- **golangci-lint:** replaced the deprecated `trace.NewNoopTracerProvider` with `trace/noop`; dropped the unused `infoln`; checked the two provider `Shutdown` errors; US-spelled two attribute strings (`order_canceled`); nolint on the one bounded `int -> byte` conversion.
- **gosec `G404`/`G706`** excluded in `.golangci.yml`: a synthetic trace generator uses `math/rand` by design and logs its own CLI flags on bad input.

No functional or telemetry change beyond punctuation and the `canceled` spelling of two attribute values.

Green locally: `go build` / `vet` / gofumpt / **golangci-lint 0 issues** / glyph guard / `go test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)