### PR TITLE
fix(release): stamp the version into the banner and container image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,3 +102,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,7 @@ builds:
       - amd64
       - arm64
     ldflags:
-      - -s -w
+      - -s -w -X main.version={{ .Version }}
 
 archives:
   - format: tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,11 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 ARG TARGETOS TARGETARCH
+# VERSION is stamped into the banner via -X main.version. release.yml passes the git
+# tag; local `docker build` defaults to "dev". Keep in sync with .goreleaser.yml.
+ARG VERSION=dev
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-    go build -ldflags="-s -w" -o /out/tracegen ./cmd/tracegen
+    go build -ldflags="-s -w -X main.version=${VERSION}" -o /out/tracegen ./cmd/tracegen
 
 # distroless/static: no shell, CA certs included (for OTLP/TLS egress), runs as non-root.
 FROM gcr.io/distroless/static-debian12:nonroot

--- a/cmd/tracegen/main.go
+++ b/cmd/tracegen/main.go
@@ -27,6 +27,11 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
+// version is stamped at release time: goreleaser -X main.version for the tarball
+// binaries, the Dockerfile VERSION build-arg for the container image. Local and dev
+// builds report "dev". It appears in the startup banner.
+var version = "dev"
+
 var (
 	tracerPool   = map[string][]trace.Tracer{}
 	loggerPool   = map[string][]logapi.Logger{}
@@ -470,7 +475,7 @@ func main() {
 
 	errorLabels := []string{"none", "rare", "rare", "low", "low", "normal", "elevated", "high", "high", "extreme", "chaos"}
 	bannerln()
-	bannerf("OpenTelemetry Trace Generator (%d services, %d pods, %d scenarios)\n", totalServices, len(pods), len(scenarios))
+	bannerf("OpenTelemetry Trace Generator %s (%d services, %d pods, %d scenarios)\n", version, totalServices, len(pods), len(scenarios))
 	bannerf("Endpoint: %s  Complexity: %s\n", endpoint, complexity)
 	bannerf("Level %d: %s  (tick=%dms, burst=%d-%d)  Errors: %s (%d)\n",
 		*level, cfg.label, cfg.tickMs, cfg.burstMin, cfg.burstMax, errorLabels[*errors], *errors)


### PR DESCRIPTION
tracegen's banner showed no version at all. Add a `version` var (default `dev`) printed in the startup banner, and stamp it two ways so both artifacts carry it:
- **goreleaser** `-X main.version={{ .Version }}` for the tarball binaries.
- **Dockerfile** `VERSION` build-arg fed to `-X main.version`; `release.yml` passes the git tag (`steps.meta.outputs.version`). The container is built by the Dockerfile, not goreleaser, so this is what fixes the image.

Banner now reads e.g. `OpenTelemetry Trace Generator 0.7.7 (28 services, ...)`. Build + vet green. Needs a new release + `image.tag` bump to reach the cluster.

No em dashes / arrows (R-LOCAL-005).

🤖 Generated with [Claude Code](https://claude.com/claude-code)