### PR TITLE
build!: drop the if- prefix from the Go module path

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This tool generates **topology-rich, failure-injectable traces from a single bin
 
 ```bash
 # Download the latest release (or build from source)
-go install github.com/ImmersiveFusion/if-opentelemetry-tracegen/cmd/tracegen@latest
+go install github.com/ImmersiveFusion/opentelemetry-tracegen/cmd/tracegen@latest
 
 # Send to a local OTLP collector (Jaeger, Tempo, etc.)
 tracegen -insecure
@@ -34,7 +34,7 @@ export OTEL_EXPORTER_OTLP_HEADERS="api-key=YOUR_KEY"
 tracegen -endpoint your-otlp-endpoint:443
 ```
 
-**Why the install path says `if-opentelemetry-tracegen`:** that is the Go module path declared in `go.mod`, and a module path is a public contract rather than a link. It keeps working for everyone who has already pinned it, so it deliberately stays as-is even though the repository is now named `opentelemetry-tracegen`. Please do not "fix" it to match the repo name.
+**Installed from the old path?** Releases up to v0.7.7 were published as `github.com/ImmersiveFusion/if-opentelemetry-tracegen`. Pinned installs of those versions keep working, but `@latest` on the old path stops resolving from v0.8.0 onward, so update your command to the path above.
 
 > **See it in 3D** - Send traces to [DeepCube (TM)](https://deepcube.ai) (`tracegen -endpoint otlp.deepcube.ai:443 -headers "api-key=YOUR_KEY"`, [how to get a key](https://docs.deepcube.ai/Getting-Started/Api-Key/)) to explore them as a 3D force-directed graph, drill into conventional trace waterfalls for detailed analysis, and get AI-assisted insights from [Tessa](https://deepcube.ai). For a ready-made example without any setup, try the [OpenTelemetry Chaos Simulator](https://github.com/ImmersiveFusion/opentelemetry-chaos-sim) at [chaos.deepcube.ai](https://chaos.deepcube.ai) - a fully interactive sandbox with visual failure injection.
 

--- a/cmd/tracegen/main.go
+++ b/cmd/tracegen/main.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ImmersiveFusion/if-opentelemetry-tracegen/internal/health"
+	"github.com/ImmersiveFusion/opentelemetry-tracegen/internal/health"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ImmersiveFusion/if-opentelemetry-tracegen
+module github.com/ImmersiveFusion/opentelemetry-tracegen
 
 go 1.25.0
 


### PR DESCRIPTION
Makes the Go module path match the repository name after the 2026-08-07 org rename. Reverses the earlier decision to leave it (#1940), on the evidence below.

## Diff

3 files, 4 lines.

| File | Change |
|---|---|
| `go.mod` | module path |
| `cmd/tracegen/main.go:15` | `internal/health` import |
| `README.md:24` | documented `go install` command |
| `README.md:37` | note rewritten as an upgrade note |

## Impact, measured rather than assumed

The earlier ruling rested on "this breaks every pinned consumer." That is not accurate for this module, and the correction is the reason for reopening it.

**This module exports no importable packages.** `cmd/tracegen` is `package main`; `internal/health` is `internal/`, which Go forbids external code from importing. No downstream module can list this in a `require` block, so there is no dependency graph to break and no `go.sum` anywhere to invalidate.

What actually breaks is the literal install command wherever it is written down (the Show HN thread, blog posts, CI scripts), and only once a tag is cut on this commit:

```
go install .../if-opentelemetry-tracegen/cmd/tracegen@latest   -> fails
go install .../if-opentelemetry-tracegen/cmd/tracegen@v0.7.7   -> still works
```

Pinned installs at v0.7.7 and earlier keep resolving from the module proxy cache indefinitely. The failure mode for `@latest` is a clear `module declares its path as` error, not a silent break.

## Sequencing, required

**v0.8.0 must be tagged as part of shipping this.** The new module path has no published version until a tag exists, so between merging and tagging the README documents a command that errors. This was verified empirically by running `go install` on the new path before any tag existed.

Merging without tagging is the one way to get this wrong.

## Verification

`go build`, `go vet`, `go test` and `gofmt` all pass. Import ordering is unchanged (`github.com` still sorts before `go.opentelemetry.io`). R-LOCAL-005 clean.