### PR TITLE
docs: three signals, not two, and the grids are pinned by tag

### DIFF
--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -2,7 +2,7 @@
      (the description API rejects PATs). When you change this, re-paste it on Docker Hub. -->
 # TraceGen
 
-**One container that emits realistic, topology-rich OpenTelemetry traces, including AI agentic spans.** No microservices to deploy, no Docker Compose with 15 containers. A single 5.7 MB image simulates a full e-commerce platform: up to 28 services, dozens of pods that scale with the topology, 40 scenario flows, and 10 injectable failure modes, with full OTel GenAI semantic conventions for LLM/agent observability.
+**One container that emits realistic, topology-rich OpenTelemetry traces, logs and metrics, including AI agentic spans.** No microservices to deploy, no Docker Compose with 15 containers. A single 5.7 MB image simulates a full e-commerce platform: up to 28 services, dozens of pods that scale with the topology, 40 scenario flows, and 10 injectable failure modes, with full OTel GenAI semantic conventions for LLM/agent observability.
 
 Built for testing observability platforms, load-testing trace pipelines, and showcasing distributed-system visualizations, for both traditional APM and LLM observability.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenTelemetry Trace Generator
 
-A single-binary distributed trace generator that produces realistic, topology-rich OTLP traces and correlated logs. No Docker Compose, no microservices to deploy, no infrastructure - just one executable (or a 5.7 MB container) that simulates a full e-commerce platform with up to 28 services, dozens of pods that scale with the topology, and 40 scenario flows - including AI agentic scenarios with full OTel GenAI semantic conventions. Three complexity levels (light/normal/heavy) let you scale from a clean 10-service demo to the full topology with AI.
+A single-binary distributed trace generator that produces realistic, topology-rich OTLP traces, correlated logs, and metrics derived from those same traces. No Docker Compose, no microservices to deploy, no infrastructure - just one executable (or a 5.7 MB container) that simulates a full e-commerce platform with up to 28 services, dozens of pods that scale with the topology, and 40 scenario flows - including AI agentic scenarios with full OTel GenAI semantic conventions. Three complexity levels (light/normal/heavy) let you scale from a clean 10-service demo to the full topology with AI.
 
 Built for testing observability platforms, load testing trace pipelines, and showcasing distributed system visualizations - for both traditional APM and LLM observability.
 
@@ -42,7 +42,7 @@ tracegen -endpoint your-otlp-endpoint:443
 
 ![The seven demo grids streaming live, in motion](.img/tracegen.gif)
 
-Seven always-on demo grids stream live OpenTelemetry traces into DeepCube's 3D player right now: a clean baseline, an AI-native app, a blended environment, phantom-service detection, an AI-outage, and a full incident. Each grid is this container, deployed declaratively via GitOps (Argo CD) in the Immersive Fusion cloud, multi-arch and distroless, one matrix row per grid, shipping to `otlp.deepcube.ai:443`.
+Seven always-on demo grids stream live OpenTelemetry traces, logs and metrics into DeepCube's 3D player right now: a clean baseline, an AI-native app, a blended environment, phantom-service detection, an AI-outage, and a full incident. Each grid is this container, deployed declaratively via GitOps (Argo CD) in the Immersive Fusion cloud, multi-arch and distroless, one matrix row per grid, shipping to `otlp.deepcube.ai:443`.
 
 **See them in 3D:** the full experience is [DeepCube](https://docs.deepcube.ai/DC/3D/), the immersive 3D client: install it and open a grid to walk the live traces. On mobile or can't install right now? [DeepCube Web](https://docs.deepcube.ai/DC/Web/) runs the same grids in your browser at [portal.deepcube.ai](https://portal.deepcube.ai).
 

--- a/WHERE-TRACEGEN-RUNS.md
+++ b/WHERE-TRACEGEN-RUNS.md
@@ -18,7 +18,7 @@ That portability is the whole point: the same image runs on a laptop, a CI runne
 ### Immersive Fusion: live public demo grids
 
 - **Where it runs:** the **Immersive Fusion cloud**: seven always-on workloads on Kubernetes, deployments managed declaratively via GitOps (Argo CD).
-- **What for:** **seven always-on public demo grids**, each one a separate TraceGen deployment streaming live OpenTelemetry traces into [DeepCube (TM)](https://deepcube.ai)'s 3D player, so anyone can open it and watch *real data moving* instead of a canned recording. Each grid is tuned to tell one story:
+- **What for:** **seven always-on public demo grids**, each one a separate TraceGen deployment streaming live OpenTelemetry traces, logs and metrics into [DeepCube (TM)](https://deepcube.ai)'s 3D player, so anyone can open it and watch *real data moving* instead of a canned recording. Each grid is tuned to tell one story:
   - **traditional-clean**, a healthy e-commerce platform: the calm, mostly-green reference graph.
   - **ai-flagship**, an AI-native application, observed: a RAG pipeline, an AI chatbot, content moderation, and a multi-step agent emitting full OTel GenAI spans.
   - **blended**, the real world, traditional + AI together: classic microservices and AI services sharing one trace graph, with real error traffic.
@@ -26,7 +26,7 @@ That portability is the whole point: the same image runs on a laptop, a CI runne
   - **ai-clean**, AI on a calm day: the agentic topology at a low error rate.
   - **traditional**, when the AI tier goes down: the full traditional platform with its AI backends erroring (rate limits, timeouts).
   - **incident**, everything is on fire: maximum errors plus dead consumers, the root-cause / incident-response demo.
-- **Flavor:** the distroless container (`immersivefusion/tracegen`, pinned by digest in GitOps, the same pin-by-digest we'd ask of you below), one Kubernetes Deployment per grid, each shipping to `otlp.deepcube.ai:443`. The three densest grids (ai-clean, traditional, incident) run at a low `-level` floor (full topology, gentle trace rate) so the 3D player stays smooth while all seven run side by side.
+- **Flavor:** the distroless container (`immersivefusion/tracegen`, pinned by tag in GitOps and bumped by Renovate, the same pin-and-version we'd ask of you below), one Kubernetes Deployment per grid, each shipping to `otlp.deepcube.ai:443`. The three densest grids (ai-clean, traditional, incident) run at a low `-level` floor (full topology, gentle trace rate) so the 3D player stays smooth while all seven run side by side.
 - **The point:** the whole image is 5.7 MB and each grid sips a few dozen megabytes of RAM, light enough that the entire fleet would cheerfully run off a Mac mini in a broom closet. (It doesn't, it runs in the Immersive Fusion cloud, but it absolutely could.) **See them live, in 3D.** The way to experience this is [DeepCube](https://docs.deepcube.ai/DC/3D/), the immersive 3D client: install it, open a demo grid, and walk the live traces in three dimensions: fly the topology, drill into a failing span, lean on Tessa, our AI assistant. That's the real thing. On a phone, or can't install right now? [DeepCube Web](https://docs.deepcube.ai/DC/Web/) runs the same grids in your browser at [portal.deepcube.ai](https://portal.deepcube.ai), sign in and open a grid. Don't want to install or sign in at all? **Watch the grids live on Twitch** at [twitch.tv/immersivefusion](https://www.twitch.tv/immersivefusion): the 3D player, streamed in real time, zero friction.
 
 ---


### PR DESCRIPTION
Four documentation claims went stale when metrics shipped in v0.8.0. No behavior change.

## Three signals, not two

The README lede, the demo-grid paragraph, and the Docker Hub overview all describe TraceGen as emitting traces and correlated logs. It emits metrics as well now, derived from the same spans, so the one-line summaries say all three.

## The grids are pinned by tag, not digest

`WHERE-TRACEGEN-RUNS.md` said:

> the distroless container (`immersivefusion/tracegen`, **pinned by digest in GitOps, the same pin-by-digest we'd ask of you below**)

That was wrong, and wrong before metrics. In IF.GitOps, `charts/tracegen/values.yaml` carries `tag: "0.8.0"` and the deployment template renders `{{ .Values.image.repository }}:{{ .Values.image.tag }}`. Renovate's helm-values manager owns the bump, which is exactly why the values file splits repository from tag.

The sentence also contradicted itself: the contribution template two sections down asks contributors for *"the image tag you run, e.g. immersivefusion/tracegen:0.6.1"*. So it claimed a digest pin while asking for a tag.

Now reads "pinned by tag in GitOps and bumped by Renovate, the same pin-and-version we'd ask of you below".

## One thing the merger needs to do by hand

`DOCKERHUB.md` is the canonical source for the Docker Hub Overview, but its own header says it is pasted onto the Hub page manually because the description API rejects PATs. **The Hub page needs re-pasting** for that line to appear publicly; merging this PR alone will not update it.

## Testing

Documentation only, no code touched. Verified the R-LOCAL-005 glyph gate passes across the tree (0 violations) since that is the check most likely to catch a prose edit.
