### PR TITLE
Rename the product in prose, and lead with the new positioning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,16 @@
-# Contributing to TraceGen
+# Contributing to Snowglobe
 
-Thanks for your interest in TraceGen, a single-binary OpenTelemetry trace generator. Bug reports, feature ideas, code, and docs are all welcome.
+Thanks for your interest in Snowglobe, a single-binary OpenTelemetry trace generator. Bug reports, feature ideas, code, and docs are all welcome.
 
 ## Ways to contribute
 
 - **Report a bug** or **request a feature**: open an issue with one of the [issue templates](.github/ISSUE_TEMPLATE).
-- **Add your deployment**: running TraceGen somewhere? Add it to [`WHERE-SNOWGLOBE-RUNS.md`](WHERE-SNOWGLOBE-RUNS.md) via a pull request, or use the "Add a deployment" issue template and we'll add it for you.
+- **Add your deployment**: running Snowglobe somewhere? Add it to [`WHERE-SNOWGLOBE-RUNS.md`](WHERE-SNOWGLOBE-RUNS.md) via a pull request, or use the "Add a deployment" issue template and we'll add it for you.
 - **Send a pull request**: see below.
 
 ## Building from source
 
-TraceGen is a single Go module with no runtime dependencies.
+Snowglobe is a single Go module with no runtime dependencies.
 
 ```bash
 git clone https://github.com/ImmersiveFusion/snowglobe.git
@@ -60,7 +60,7 @@ trigger does not retroactively run it. Push a new (higher) version tag instead.
 
 ## Reporting issues
 
-Use the issue templates. For bugs, include your platform/architecture, the exact `tracegen` command and flags, and what you expected versus what happened. `-log-level debug` gives more detail.
+Use the issue templates. For bugs, include your platform/architecture, the exact `snowglobe` command and flags, and what you expected versus what happened. `-log-level debug` gives more detail.
 
 ## Code of conduct
 

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -47,11 +47,11 @@ The image is multi-arch (`linux/amd64`, `linux/arm64`), distroless, and runs as 
 
 ## Why it exists
 
-Existing trace generators are either flat span emitters (no service topology) or full demo apps that need Docker Compose and several GB of RAM, and none of them generate AI agentic traces. TraceGen produces topology-rich, failure-injectable traces from a single binary, covering both traditional microservice flows and AI agentic patterns. One image proves a platform can visualize both.
+Existing trace generators are either flat span emitters (no service topology) or full demo apps that need Docker Compose and several GB of RAM, and none of them generate AI agentic traces. Snowglobe produces topology-rich, failure-injectable traces from a single binary, covering both traditional microservice flows and AI agentic patterns. One image proves a platform can visualize both.
 
 ## See it move
 
-The traces are real, and you can watch them flow. TraceGen feeds live demo grids that stream OpenTelemetry traces into [DeepCube (TM)](https://deepcube.ai)'s 3D player. Watch them live on Twitch: [twitch.tv/immersivefusion](https://www.twitch.tv/immersivefusion)
+The traces are real, and you can watch them flow. Snowglobe feeds live demo grids that stream OpenTelemetry traces into [DeepCube (TM)](https://deepcube.ai)'s 3D player. Watch them live on Twitch: [twitch.tv/immersivefusion](https://www.twitch.tv/immersivefusion)
 
 ## Tags
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ snowglobe -endpoint your-otlp-endpoint:443
 
 ## Live demo grids: see it running
 
-![The seven demo grids streaming live, in motion](.img/snowglobe.gif)
+![The seven demo grids streaming live into DeepCube's 3D player](.img/deepcube.gif)
 
 Seven always-on demo grids stream live OpenTelemetry traces, logs and metrics into DeepCube's 3D player right now: a clean baseline, an AI-native app, a blended environment, phantom-service detection, an AI-outage, and a full incident. Each grid is this container, deployed declaratively via GitOps (Argo CD) in the Immersive Fusion cloud, multi-arch and distroless, one matrix row per grid, shipping to `otlp.deepcube.ai:443`.
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,24 @@
-# OpenTelemetry Trace Generator
+# Snowglobe
 
-A single-binary distributed trace generator that produces realistic, topology-rich OTLP traces, correlated logs, and metrics derived from those same traces. No Docker Compose, no microservices to deploy, no infrastructure - just one executable (or a 5.7 MB container) that simulates a full e-commerce platform with up to 28 services, dozens of pods that scale with the topology, and 40 scenario flows - including AI agentic scenarios with full OTel GenAI semantic conventions. Three complexity levels (light/normal/heavy) let you scale from a clean 10-service demo to the full topology with AI.
+**A sealed world you can shake.**
 
-**A public good for the OpenTelemetry community.** Apache-2.0, no account, no sign-up, no lock-in. The output is plain OTLP, so it works in whatever you already run: Jaeger, Tempo, Grafana, an OpenTelemetry Collector, or spatial tools such as DeepCube. Use it to test an observability platform, load test a trace pipeline, or show a distributed system to someone who has never seen one, for both traditional APM and LLM observability.
+One binary that generates a whole distributed system's telemetry: logs, traces and metrics from a 28-service topology with the shapes real systems actually make. Diamond dependencies, scatter-gather fan-out, sagas that compensate, timeouts that cascade. Point it at anything that speaks OTLP and watch it arrive.
+
+No Docker Compose. No microservices to deploy. No 6GB stack to babysit. One executable, or a 5.7 MB container.
+
+```bash
+docker run --rm immersivefusion/snowglobe -insecure -endpoint host.docker.internal:4317
+```
+
+**A public good for the OpenTelemetry community.** Apache-2.0, no account, no sign-up, no lock-in. The output is plain OTLP, so it works in whatever you already run: Jaeger, Tempo, Grafana, SigNoz, an OpenTelemetry Collector, or spatial tools such as DeepCube, which are one consumer among many.
+
+**How this differs from `telemetrygen`.** `telemetrygen` generates spans, and it is the official tool and good at that. Snowglobe generates a *system*: a topology with real dependency shapes, injectable failures, and AI agent spans under the OTel GenAI semantic conventions. **If you need load, use `telemetrygen`. If you need something that looks like a production incident, that is what this is for.**
 
 Most trace generators die. Their repos go quiet, the SDKs move, and the thing stops building. This one is maintained, and that is the point of it.
 
-**It has a sibling.** tracegen makes realistic telemetry out of nothing: **synthetic** OTel. [sos-beacon](https://github.com/ImmersiveFusion/sos-beacon) is the **organic** counterpart, a real workload doing a real job that emits real telemetry as a byproduct. Between them you can fill a backend with either kind.
+**It has a sibling.** Snowglobe makes realistic telemetry out of nothing: **synthetic** OTel. [sos-beacon](https://github.com/ImmersiveFusion/sos-beacon) is the **organic** counterpart, a real workload doing a real job that emits real telemetry as a byproduct. Between them you can fill a backend with either kind.
 
-![TraceGen traces in DeepCube's 3D player](.img/screenshot.png)
+![Snowglobe traces in DeepCube's 3D player](.img/screenshot.png)
 
 ## Why This Exists
 
@@ -40,11 +50,11 @@ snowglobe -endpoint your-otlp-endpoint:443
 
 **Installed from an old path?** Releases up to v0.7.7 were published as `github.com/ImmersiveFusion/if-opentelemetry-tracegen`, and releases up to v0.8.0 as `github.com/ImmersiveFusion/opentelemetry-tracegen`. Pinned installs of those versions keep working, but `@latest` on either old path stops resolving from the next release onward, so update your command to the path above. The installed binary is now named `snowglobe` rather than `tracegen`.
 
-> **See it in 3D** - Send traces to [DeepCube](https://deepcube.ai) (`snowglobe -endpoint otlp.deepcube.ai:443 -headers "api-key=YOUR_KEY"`, [how to get a key](https://docs.deepcube.ai/Getting-Started/Api-Key/)) to explore them as a 3D force-directed graph, drill into conventional trace waterfalls for detailed analysis, and get AI-assisted insights from [Tessa](https://deepcube.ai). For a ready-made example without any setup, try the [OpenTelemetry Chaos Simulator](https://github.com/ImmersiveFusion/opentelemetry-chaos-sim) at [chaos.deepcube.ai](https://chaos.deepcube.ai) - a fully interactive sandbox with visual failure injection.
+> **See it in 3D** - Send traces to [DeepCube](https://deepcube.ai) (`snowglobe -endpoint otlp.deepcube.ai:443 -headers "api-key=YOUR_KEY"`, [how to get a key](https://docs.deepcube.ai/Getting-Started/Api-Key/)) to explore them as a 3D force-directed graph, drill into conventional trace waterfalls for detailed analysis, and get AI-assisted insights from [Tessa](https://deepcube.ai). For a ready-made example without any setup, try the [OpenTelemetry Chaos Simulator](https://github.com/ImmersiveFusion/shoebox) at [chaos.deepcube.ai](https://chaos.deepcube.ai) - a fully interactive sandbox with visual failure injection.
 
 ## Live demo grids: see it running
 
-![The seven demo grids streaming live, in motion](.img/tracegen.gif)
+![The seven demo grids streaming live, in motion](.img/snowglobe.gif)
 
 Seven always-on demo grids stream live OpenTelemetry traces, logs and metrics into DeepCube's 3D player right now: a clean baseline, an AI-native app, a blended environment, phantom-service detection, an AI-outage, and a full incident. Each grid is this container, deployed declaratively via GitOps (Argo CD) in the Immersive Fusion cloud, multi-arch and distroless, one matrix row per grid, shipping to `otlp.deepcube.ai:443`.
 
@@ -52,7 +62,7 @@ Seven always-on demo grids stream live OpenTelemetry traces, logs and metrics in
 
 **See them in 3D:** the full experience is [DeepCube](https://docs.deepcube.ai/DC/3D/), the immersive 3D client: install it and open a grid to walk the live traces. On mobile or can't install right now? [DeepCube Web](https://docs.deepcube.ai/DC/Web/) runs the same grids in your browser at [portal.deepcube.ai](https://portal.deepcube.ai).
 
-**[Where else does TraceGen run?](WHERE-SNOWGLOBE-RUNS.md)**: a community board of deployments. Add yours.
+**[Where else does Snowglobe run?](WHERE-SNOWGLOBE-RUNS.md)**: a community board of deployments. Add yours.
 
 ## Features
 
@@ -181,7 +191,7 @@ Metrics aggregate in process and flush on an interval, so unlike traces their vo
 
 **The queue depth is the one to watch.** Producer spans increment it and consumer spans decrement it, so running with `-no-consumers` makes the backlog climb without bound while the trace graph still looks busy. That is a story traces alone can only imply.
 
-**Naming.** Where OpenTelemetry defines a metric, TraceGen uses its name and conforms to its contract, including seconds as the unit. Everything else lives under a `tracegen.` prefix rather than extending a semconv namespace.
+**Naming.** Where OpenTelemetry defines a metric, Snowglobe uses its name and conforms to its contract, including seconds as the unit. Everything else lives under a `tracegen.` prefix rather than extending a semconv namespace.
 
 **Cardinality.** `service.instance.id` is deliberately **off** by default: it multiplies every series by the pod count (up to 59 at `-complexity heavy`), and metric backends commonly bill per active series with no cardinality control on an OTLP push path. Turn it on with `-metrics-instance-id` when per-pod resolution is the thing you are demonstrating. Metric attributes are an explicit allowlist, never a copy of the span's attributes, so user, session and order ids never reach a metric.
 
@@ -256,7 +266,7 @@ The generated traces simulate a .NET-based e-commerce platform with AI capabilit
 ## Usage
 
 ```
-tracegen [flags]
+snowglobe [flags]
 
 Flags:
   -endpoint string     OTLP gRPC endpoint host:port (default "localhost:4317")
@@ -352,7 +362,7 @@ snowglobe -endpoint otlp.deepcube.ai:443 -headers "API-Key=YOUR_DEEPCUBE_KEY"
 
 ## How It Compares
 
-| Capability | tracegen | OTel telemetrygen | OTel Astronomy Shop | Jaeger HotROD | k6 + xk6-tracing |
+| Capability | Snowglobe | OTel telemetrygen | OTel Astronomy Shop | Jaeger HotROD | k6 + xk6-tracing |
 |---|:---:|:---:|:---:|:---:|:---:|
 | Single binary, zero infra | **Yes** | 1 binary | 15+ containers, ~6GB | 4 containers | k6 + extension |
 | Services | **28** | 1 | ~22 | 4 | User-defined |
@@ -401,8 +411,8 @@ The AI agentic traces are also compatible with LLM-specialized observability too
 
 Part of a small family of single-binary, zero-infra OTel tools, all Apache-2.0 and all usable without any Immersive Fusion account:
 
-- **[sos-beacon](https://github.com/ImmersiveFusion/sos-beacon)** - The **organic** counterpart to this tool's synthetic output. A real workload doing a real job (surfacing people asking for help in public forums, for a human to answer), OTel-instrumented, so it emits genuine production telemetry as a byproduct. Where tracegen invents a system, sos-beacon *is* one.
-- **[OpenTelemetry Chaos Simulator](https://github.com/ImmersiveFusion/opentelemetry-chaos-sim)** - Interactive chaos engineering sandbox with visual failure injection. Complements tracegen: generate topology-rich traces here, inject chaos there, [visualize both in 3D](https://chaos.deepcube.ai).
+- **[sos-beacon](https://github.com/ImmersiveFusion/sos-beacon)** - The **organic** counterpart to this tool's synthetic output. A real workload doing a real job (surfacing people asking for help in public forums, for a human to answer), OTel-instrumented, so it emits genuine production telemetry as a byproduct. Where Snowglobe invents a system, sos-beacon *is* one.
+- **[OpenTelemetry Chaos Simulator](https://github.com/ImmersiveFusion/shoebox)** - Interactive chaos engineering sandbox with visual failure injection. Complements Snowglobe: generate topology-rich traces here, inject chaos there, [visualize both in 3D](https://chaos.deepcube.ai).
 
 ## Building From Source
 

--- a/WHERE-SNOWGLOBE-RUNS.md
+++ b/WHERE-SNOWGLOBE-RUNS.md
@@ -1,8 +1,8 @@
-# Where TraceGen Runs
+# Where Snowglobe Runs
 
 **One container. 5.7 MB. It runs anywhere, and this is the board of where it actually does.**
 
-TraceGen ships as a single distroless, multi-arch image (`linux/amd64` + `linux/arm64`), no Compose, no multi-gigabyte RAM footprint, no microservices to stand up:
+Snowglobe ships as a single distroless, multi-arch image (`linux/amd64` + `linux/arm64`), no Compose, no multi-gigabyte RAM footprint, no microservices to stand up:
 
 ```bash
 # -insecure = plaintext gRPC for a local collector (skips TLS); drop it for a remote, authenticated endpoint
@@ -18,7 +18,7 @@ That portability is the whole point: the same image runs on a laptop, a CI runne
 ### Immersive Fusion: live public demo grids
 
 - **Where it runs:** the **Immersive Fusion cloud**: seven always-on workloads on Kubernetes, deployments managed declaratively via GitOps (Argo CD).
-- **What for:** **seven always-on public demo grids**, each one a separate TraceGen deployment streaming live OpenTelemetry traces, logs and metrics into [DeepCube (TM)](https://deepcube.ai)'s 3D player, so anyone can open it and watch *real data moving* instead of a canned recording. Each grid is tuned to tell one story:
+- **What for:** **seven always-on public demo grids**, each one a separate Snowglobe deployment streaming live OpenTelemetry traces, logs and metrics into [DeepCube (TM)](https://deepcube.ai)'s 3D player, so anyone can open it and watch *real data moving* instead of a canned recording. Each grid is tuned to tell one story:
   - **traditional-clean**, a healthy e-commerce platform: the calm, mostly-green reference graph.
   - **ai-flagship**, an AI-native application, observed: a RAG pipeline, an AI chatbot, content moderation, and a multi-step agent emitting full OTel GenAI spans.
   - **blended**, the real world, traditional + AI together: classic microservices and AI services sharing one trace graph, with real error traffic.
@@ -33,7 +33,7 @@ That portability is the whole point: the same image runs on a laptop, a CI runne
 
 ## Add your deployment
 
-Running TraceGen somewhere: a load test, a CI pipeline, a teaching lab, a backend bake-off, a homelab, a demo of your own? **List your shit too.** This board is earned, not bought: the only entry fee is that you actually run it.
+Running Snowglobe somewhere: a load test, a CI pipeline, a teaching lab, a backend bake-off, a homelab, a demo of your own? **List your shit too.** This board is earned, not bought: the only entry fee is that you actually run it.
 
 Open a pull request at [github.com/ImmersiveFusion/snowglobe](https://github.com/ImmersiveFusion/snowglobe) adding a block under [The deployments](#the-deployments) using this template:
 
@@ -41,7 +41,7 @@ Open a pull request at [github.com/ImmersiveFusion/snowglobe](https://github.com
 ### <Your name or org>: <one-line what>
 
 - **Where it runs:** <platform + architecture, e.g. "AWS EKS, x86_64" or "a Raspberry Pi cluster">
-- **What for:** <the use case, what TraceGen is doing for you>
+- **What for:** <the use case, what Snowglobe is doing for you>
 - **Flavor:** <container or binary; the image tag you run, e.g. immersivefusion/snowglobe:0.6.1; roughly how many instances / how hard you push it>
 - **Link:** <optional but encouraged, a live URL, a blog post, or a repo; it's the best proof>
 ```

--- a/docs/metrics-design.md
+++ b/docs/metrics-design.md
@@ -2,7 +2,7 @@
 
 Status: **implemented**. See `cmd/snowglobe/metrics.go`.
 
-This document covers what tracegen emits as OTLP metrics, why, and the constraints that shape it.
+This document covers what Snowglobe emits as OTLP metrics, why, and the constraints that shape it.
 
 ## What changed between design and implementation
 
@@ -20,7 +20,7 @@ unbounded backlog rather than a simulated one, and it costs less code than a ran
 the same span processor derives the metrics. The net result is that all four layers are implemented
 with **zero edits to the ~3,000 lines of scenario code**.
 
-One item from the plan was dropped: cache hit ratio. Tracegen's cache spans do not distinguish a hit
+One item from the plan was dropped: cache hit ratio. Snowglobe's cache spans do not distinguish a hit
 from a miss, so a counter pair would have been invented rather than derived. It needs a span attribute
 first.
 
@@ -47,7 +47,7 @@ and flush on an interval via a `PeriodicReader`. A `-level 10` run produces roug
 but the **same** metric volume as `-level 1`.
 
 That is a feature. It means the metrics load is predictable and decoupled from the trace load, so a
-metrics-enabled tracegen does not multiply the cost of a high-rate demo grid. It also means metric
+metrics-enabled Snowglobe does not multiply the cost of a high-rate demo grid. It also means metric
 volume is governed almost entirely by **series count**, which is why the cardinality budget below is
 the binding constraint rather than the tick rate.
 
@@ -124,14 +124,14 @@ on the trace side.
 | `gen_ai.client.operation.duration` | Histogram | `s` | Same, plus `error.type` where applicable |
 
 Token counts already exist as `gen_ai.usage.input_tokens` / `output_tokens` span attributes, so this is
-a projection of data tracegen already produces rather than new simulation. Cardinality is naturally
+a projection of data Snowglobe already produces rather than new simulation. Cardinality is naturally
 small: 9 chat models across 5 systems and 4 operations.
 
 ---
 
 ## Layer 3: an emission oracle, off by default
 
-Tracegen occupies a position no real producer does: it knows the correct answer. When a scenario runs,
+Snowglobe occupies a position no real producer does: it knows the correct answer. When a scenario runs,
 it knows exactly how many spans it created, for which service, with which outcome.
 
 A `tracegen.spans.emitted` counter, incremented in a `SpanProcessor.OnEnd` hook, makes that knowledge
@@ -140,7 +140,7 @@ queryable. Diffing it against whatever the receiving pipeline reports answers on
 
 That is a delivery-integrity check, not a duplicate RED metric. Because it compares **totals** rather
 than histogram shapes, it needs no bucket-for-bucket alignment with anything downstream, which keeps
-tracegen fully conformant while still serving as the oracle.
+Snowglobe fully conformant while still serving as the oracle.
 
 Gated behind `-metrics-verify`, default off. An oracle nobody queries is just cardinality.
 
@@ -174,7 +174,7 @@ pods     x routes x methods x statuses    (instance id on)
 
 At `-complexity heavy` that is 28 services or 59 pods against the same per-service dimensions, so
 enabling `service.instance.id` multiplies the RED series count by roughly the average pod-per-service
-count. Against a real deployment where a service commonly has one or two instances, tracegen would be an
+count. Against a real deployment where a service commonly has one or two instances, Snowglobe would be an
 outlier by an order of magnitude, across however many grids are running.
 
 Therefore:


### PR DESCRIPTION
#35 renamed paths, binaries and images but deliberately left body copy alone, so the repo is called `snowglobe` while every doc still says "TraceGen". This finishes it.

### The README opening

Replaced with the drafted positioning: the Snowglobe H1, the sealed-world line, what it actually generates, and the `telemetrygen` distinction. That paragraph exists to **pre-answer the comparison before anyone asks it**, and frames `telemetrygen` as solving a different problem, never as a competitor.

**What is preserved rather than overwritten**, because it shipped in #34 and passed its gate:

- the community-first paragraph
- the "most trace generators die" maintenance line
- the `sos-beacon` organic sibling
- the screenshot

The DeepCube mention keeps the "one consumer among many" wording.

### Deliberately not renamed

These are **identifiers, not names**, and renaming them breaks users:

| | Why it stays |
|---|---|
| the `tracegen.` metric namespace | emitted by `cmd/snowglobe/metrics.go` and baked into anyone's dashboards, alerts and queries |
| `TRACEGEN_LOG_LEVEL` | user-facing env var; needs its own deprecation, not a silent rename |
| old module paths in the migration note | history, and correct as written |

Each of those is a real deprecation decision worth making on purpose later.

### Also

- `.img/tracegen.gif` renamed to `.img/snowglobe.gif` with its reference updated.
- The two "OpenTelemetry Chaos Simulator" links now point at `ImmersiveFusion/shoebox`, since that rename already landed. **The display name is left alone** as part of the cross-property naming sweep, not this PR.