### PR TITLE
Fix the release asset glob, and publish only to the snowglobe image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
-          files: tracegen-*
+          files: snowglobe-*
           generate_release_notes: true
 
   # Build + push the multi-arch container image to Docker Hub. Published to BOTH

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,9 +65,9 @@ jobs:
           files: snowglobe-*
           generate_release_notes: true
 
-  # Build + push the multi-arch container image to Docker Hub. Published to BOTH
-  # immersivefusion/snowglobe (canonical) and immersivefusion/tracegen (legacy alias),
-  # identical manifests, so existing `docker run immersivefusion/tracegen` keeps working.
+  # Build + push the multi-arch container image to Docker Hub (immersivefusion/snowglobe).
+  # The former immersivefusion/tracegen repo is archived, so it is read-only and must NOT
+  # be listed here: a push to it would fail the job. Its existing tags stay pullable.
   # Runs on the same version-tag trigger as the binaries above. Independent of `build`.
   # Requires repo secret: DOCKERHUB_TOKEN (username is the public namespace, hardcoded below).
   docker:
@@ -91,9 +91,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: |
-            immersivefusion/snowglobe
-            immersivefusion/tracegen
+          images: immersivefusion/snowglobe
           tags: |
             type=semver,pattern={{version}}
             type=raw,value=latest

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -20,7 +20,7 @@ docker run --rm immersivefusion/snowglobe -insecure -endpoint host.docker.intern
 
 The image is multi-arch (`linux/amd64`, `linux/arm64`), distroless, and runs as non-root.
 
-**Previously `immersivefusion/tracegen`.** That name still works and still receives every release, so existing commands and pinned tags keep running. New usage should prefer `immersivefusion/snowglobe`.
+**Previously `immersivefusion/tracegen`.** That repository is archived and no longer receives releases. Its existing tags stay pullable, so pinned commands keep running, but anything tracking `latest` should move to `immersivefusion/snowglobe`.
 
 ## Three things to try
 


### PR DESCRIPTION
Two release-pipeline corrections.

### 1. The release asset glob shipped v0.9.0 with no binaries

The rename in #35 changed the build output and artifact names to `snowglobe-*` but missed one glob in the `release` job:

```yaml
files: tracegen-*
```

`softprops/action-gh-release` matched nothing, uploaded nothing, and **reported success**, because a glob with no matches is not an error. My bug from #35.

| Release | Assets |
|---|---|
| v0.7.8 | 4 |
| v0.8.0 | 4 |
| **v0.9.0** | **0** |

### 2. Dual-publish removed, because the old Docker repo is archived

`immersivefusion/tracegen` has been archived, which makes it read-only. Leaving it in the `metadata-action` image list would **fail the docker job on the next release**, so this removes it rather than leaving a latent break. The workflow comment records why it must not be added back.

`DOCKERHUB.md` no longer claims the old name still receives releases, which stopped being true on archive. It now says pinned tags keep working while anything tracking `latest` should move.

### Recovering v0.9.0's binaries

**Do not move the v0.9.0 tag.** The Go module proxy has cached it at `a94bf11`; re-pointing would cause checksum mismatches for anyone who has fetched it.

Once this merges, either attach the four binaries to v0.9.0 with `gh release upload`, or cut v0.9.1. The first keeps binaries and the published Docker tags aligned at 0.9.0.

### Verified working and unaffected

- `go install github.com/ImmersiveFusion/snowglobe/cmd/snowglobe@latest` resolves v0.9.0, builds, and runs.
- `immersivefusion/snowglobe` published `0.9.0` and `latest` correctly.