### PR TITLE
Call Shoebox by its name

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ snowglobe -endpoint your-otlp-endpoint:443
 
 **Installed from an old path?** Releases up to v0.7.7 were published as `github.com/ImmersiveFusion/if-opentelemetry-tracegen`, and releases up to v0.8.0 as `github.com/ImmersiveFusion/opentelemetry-tracegen`. Pinned installs of those versions keep working, but `@latest` on either old path stops resolving from the next release onward, so update your command to the path above. The installed binary is now named `snowglobe` rather than `tracegen`.
 
-> **See it in 3D** - Send traces to [DeepCube](https://deepcube.ai) (`snowglobe -endpoint otlp.deepcube.ai:443 -headers "api-key=YOUR_KEY"`, [how to get a key](https://docs.deepcube.ai/Getting-Started/Api-Key/)) to explore them as a 3D force-directed graph, drill into conventional trace waterfalls for detailed analysis, and get AI-assisted insights from [Tessa](https://deepcube.ai). For a ready-made example without any setup, try [Shoebox](https://github.com/ImmersiveFusion/shoebox) at [chaos.deepcube.ai](https://chaos.deepcube.ai) - paste a diagram of a system, break a call in it, and fire one request through.
+> **See it in 3D** - Send traces to [DeepCube](https://deepcube.ai) (`snowglobe -endpoint otlp.deepcube.ai:443 -headers "api-key=YOUR_KEY"`, [how to get a key](https://docs.deepcube.ai/Getting-Started/Api-Key/)) to explore them as a 3D force-directed graph, drill into conventional trace waterfalls for detailed analysis, and get AI-assisted insights from [Tessa](https://deepcube.ai). For a ready-made example without any setup, try [Shoebox](https://github.com/ImmersiveFusion/shoebox) at [shoebox.deepcube.ai](https://shoebox.deepcube.ai) - paste a diagram of a system, break a call in it, and fire one request through.
 
 ## Live demo grids: see it running
 
@@ -414,7 +414,7 @@ The AI agentic traces are also compatible with LLM-specialized observability too
 Part of a small family of single-binary, zero-infra OTel tools, all Apache-2.0 and all usable without any Immersive Fusion account:
 
 - **[sos-beacon](https://github.com/ImmersiveFusion/sos-beacon)** - The **organic** counterpart to this tool's synthetic output. A real workload doing a real job (surfacing people asking for help in public forums, for a human to answer), OTel-instrumented, so it emits genuine production telemetry as a byproduct. Where Snowglobe invents a system, sos-beacon *is* one.
-- **[Shoebox](https://github.com/ImmersiveFusion/shoebox)** - The world you build, where Snowglobe is the world pre-made. Paste a Mermaid diagram of a system, break something in it, fire one request, and read what comes out. A snowglobe is sealed; in a shoebox you can open it up. [See both in 3D](https://chaos.deepcube.ai).
+- **[Shoebox](https://github.com/ImmersiveFusion/shoebox)** - The world you build, where Snowglobe is the world pre-made. Paste a Mermaid diagram of a system, break something in it, fire one request, and read what comes out. A snowglobe is sealed; in a shoebox you can open it up. [See both in 3D](https://shoebox.deepcube.ai).
 
 ## Building From Source
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ snowglobe -endpoint your-otlp-endpoint:443
 
 **Installed from an old path?** Releases up to v0.7.7 were published as `github.com/ImmersiveFusion/if-opentelemetry-tracegen`, and releases up to v0.8.0 as `github.com/ImmersiveFusion/opentelemetry-tracegen`. Pinned installs of those versions keep working, but `@latest` on either old path stops resolving from the next release onward, so update your command to the path above. The installed binary is now named `snowglobe` rather than `tracegen`.
 
-> **See it in 3D** - Send traces to [DeepCube](https://deepcube.ai) (`snowglobe -endpoint otlp.deepcube.ai:443 -headers "api-key=YOUR_KEY"`, [how to get a key](https://docs.deepcube.ai/Getting-Started/Api-Key/)) to explore them as a 3D force-directed graph, drill into conventional trace waterfalls for detailed analysis, and get AI-assisted insights from [Tessa](https://deepcube.ai). For a ready-made example without any setup, try the [OpenTelemetry Chaos Simulator](https://github.com/ImmersiveFusion/shoebox) at [chaos.deepcube.ai](https://chaos.deepcube.ai) - a fully interactive sandbox with visual failure injection.
+> **See it in 3D** - Send traces to [DeepCube](https://deepcube.ai) (`snowglobe -endpoint otlp.deepcube.ai:443 -headers "api-key=YOUR_KEY"`, [how to get a key](https://docs.deepcube.ai/Getting-Started/Api-Key/)) to explore them as a 3D force-directed graph, drill into conventional trace waterfalls for detailed analysis, and get AI-assisted insights from [Tessa](https://deepcube.ai). For a ready-made example without any setup, try [Shoebox](https://github.com/ImmersiveFusion/shoebox) at [chaos.deepcube.ai](https://chaos.deepcube.ai) - paste a diagram of a system, break a call in it, and fire one request through.
 
 ## Live demo grids: see it running
 
@@ -193,7 +193,7 @@ Metrics aggregate in process and flush on an interval, so unlike traces their vo
 
 **The queue depth is the one to watch.** Producer spans increment it and consumer spans decrement it, so running with `-no-consumers` makes the backlog climb without bound while the trace graph still looks busy. That is a story traces alone can only imply.
 
-**Naming.** Where OpenTelemetry defines a metric, Snowglobe uses its name and conforms to its contract, including seconds as the unit. Everything else lives under a `tracegen.` prefix rather than extending a semconv namespace.
+**Naming.** Where OpenTelemetry defines a metric, Snowglobe uses its name and conforms to its contract, including seconds as the unit. Everything else lives under a `tracegen.` prefix rather than extending a semconv namespace. That prefix keeps the old name on purpose: a metric name is a wire contract, and renaming it to `snowglobe.` would break every dashboard and alert already keyed on it. Do not sweep it.
 
 **Cardinality.** `service.instance.id` is deliberately **off** by default: it multiplies every series by the pod count (up to 59 at `-complexity heavy`), and metric backends commonly bill per active series with no cardinality control on an OTLP push path. Turn it on with `-metrics-instance-id` when per-pod resolution is the thing you are demonstrating. Metric attributes are an explicit allowlist, never a copy of the span's attributes, so user, session and order ids never reach a metric.
 
@@ -414,7 +414,7 @@ The AI agentic traces are also compatible with LLM-specialized observability too
 Part of a small family of single-binary, zero-infra OTel tools, all Apache-2.0 and all usable without any Immersive Fusion account:
 
 - **[sos-beacon](https://github.com/ImmersiveFusion/sos-beacon)** - The **organic** counterpart to this tool's synthetic output. A real workload doing a real job (surfacing people asking for help in public forums, for a human to answer), OTel-instrumented, so it emits genuine production telemetry as a byproduct. Where Snowglobe invents a system, sos-beacon *is* one.
-- **[OpenTelemetry Chaos Simulator](https://github.com/ImmersiveFusion/shoebox)** - Interactive chaos engineering sandbox with visual failure injection. Complements Snowglobe: generate topology-rich traces here, inject chaos there, [visualize both in 3D](https://chaos.deepcube.ai).
+- **[Shoebox](https://github.com/ImmersiveFusion/shoebox)** - The world you build, where Snowglobe is the world pre-made. Paste a Mermaid diagram of a system, break something in it, fire one request, and read what comes out. A snowglobe is sealed; in a shoebox you can open it up. [See both in 3D](https://chaos.deepcube.ai).
 
 ## Building From Source
 


### PR DESCRIPTION
The chaos simulator was renamed to Shoebox on GitHub on 2026-08-20. The URLs in
this README were updated with it, but two places still carried the retired
product name in the link text, so a reader met "OpenTelemetry Chaos Simulator"
and landed on a repo called shoebox.

Both now describe what Shoebox actually is, sourced from its own README rather
than from the old positioning: paste a Mermaid diagram, break something in it,
fire one request. "Visual failure injection" described the previous version,
which is still what `chaos.deepcube.ai` serves, so the link stays pointing there
and only the name and the description move.

## Deliberately not renamed, each verified first

**The `tracegen.` metric prefix stays.** It is still what the binary emits, at
`cmd/snowglobe/metrics.go:215` and `:283`. A metric name is a wire contract, and
renaming it would break every dashboard and alert already keyed on it. The
naming section now says that inline so the next rename sweep does not have to
work it out.

**The old-path install note stays exactly as written.** It is load-bearing
precisely because it names `if-opentelemetry-tracegen` and
`opentelemetry-tracegen`: that is what makes it findable by someone stuck on an
old path.

**`go install` on the new module path is correct as it stands.** It was reported
as failing on a module-path mismatch. It resolves: the module rename in
`32b3379` is an ancestor of `v0.9.1`, and that tag's `go.mod` carries the new
path. The report predates `v0.9.0` and `v0.9.1` being cut.

## Scope

README only. The rest of this repo carries no retired names. Shoebox's own
README was checked in the same pass and needed nothing: all four Snowglobe
references already use the new name and URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
