### PR TITLE
fix(otel): conform to current semantic conventions, all three seams (OTEL-CONF e-001)

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Metrics aggregate in process and flush on an interval, so unlike traces their vo
 | `http.server.request.duration` | Histogram (s) | RED metrics per route, method and status. Semconv names, seconds, spec bucket boundaries |
 | `http.server.active_requests` | UpDownCounter | In-flight requests, rising and falling with real scenario concurrency |
 | `system.cpu.utilization` | Gauge | Driven by each service's actual span volume, not a random walk |
-| `system.memory.usage` | Gauge | Resident memory, drifting with load |
+| `system.memory.usage` | UpDownCounter | Resident memory, drifting with load. Carries `system.memory.state` |
 | `db.client.connection.count` | UpDownCounter | Pool occupancy split `used`/`idle`, tracking real database spans |
 | `tracegen.messaging.queue.depth` | Gauge | Published minus consumed, per destination |
 | `gen_ai.client.token.usage` | Histogram | Input and output tokens by model, system and operation |
@@ -217,7 +217,7 @@ All AI scenarios emit spans following [OTel GenAI Semantic Conventions](https://
 
 **Attributes on every LLM span:**
 
-- `gen_ai.system` - LLM provider (e.g., `openai`)
+- `gen_ai.provider.name` - LLM provider (e.g., `openai`)
 - `gen_ai.request.model` / `gen_ai.response.model` - model requested and used
 - `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens` - token consumption
 - `gen_ai.response.finish_reasons` - completion reason (`stop`, `tool_calls`, `length`, `content_filter`)

--- a/cmd/snowglobe/helpers.go
+++ b/cmd/snowglobe/helpers.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/rand"
+	"net/url"
 	"strings"
 	"time"
 
@@ -211,11 +212,21 @@ func randomHex(n int) string {
 // ─── GenAI Model Registry ────────────────────────────────────────────────────
 // Current models across providers, randomized per span for realistic variety.
 
+// urlHost pulls the host out of an absolute URL for the Required server.address
+// dimension on HTTP client spans. Kept deliberately small: these endpoints are
+// literals in this file, not user input.
+func urlHost(raw string) string {
+	if u, err := url.Parse(raw); err == nil && u.Host != "" {
+		return u.Hostname()
+	}
+	return raw
+}
+
 type modelInfo struct {
 	name     string // model identifier
-	system   string // gen_ai.system value
+	system   string // gen_ai.provider.name value
 	endpoint string // API endpoint URL
-	peer     string // peer.service value
+	peer     string // service.peer.name value
 }
 
 // Chat/completion models: mix of providers and tiers
@@ -251,7 +262,8 @@ func randomEmbeddingModel() modelInfo { return embeddingModels[rand.Intn(len(emb
 
 // ─── GenAI Helper Functions ───────────────────────────────────────────────────
 // These produce spans matching Microsoft Semantic Kernel / Agent Framework OTel
-// output and OTel GenAI Semantic Conventions v1.38.0.
+// output and the OTel GenAI Semantic Conventions as of v1.39.0 (gen_ai.provider.name,
+// renamed from gen_ai.system in v1.37.0).
 
 // chatSpan creates a "chat {model}" span on llm-gateway with standard gen_ai attributes.
 func chatSpan(ctx context.Context, m modelInfo, inputTokens, outputTokens int, finishReasons ...string) (context.Context, trace.Span) {
@@ -262,17 +274,19 @@ func chatSpan(ctx context.Context, m modelInfo, inputTokens, outputTokens int, f
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
 			attribute.String("gen_ai.operation.name", "chat"),
-			attribute.String("gen_ai.system", m.system),
+			attribute.String("gen_ai.provider.name", m.system),
 			attribute.String("gen_ai.request.model", m.name),
 			attribute.String("gen_ai.response.model", m.name),
 			attribute.Int("gen_ai.usage.input_tokens", inputTokens),
 			attribute.Int("gen_ai.usage.output_tokens", outputTokens),
 			attribute.StringSlice("gen_ai.response.finish_reasons", finishReasons),
 			attribute.String("gen_ai.response.id", "chatcmpl-"+randomHex(24)),
-			attribute.String("http.method", "POST"),
-			attribute.String("http.url", m.endpoint),
-			attribute.String("peer.service", m.peer),
-			attribute.Int("http.status_code", 200),
+			attribute.String("http.request.method", "POST"),
+			attribute.String("url.full", m.endpoint),
+			attribute.String("server.address", urlHost(m.endpoint)),
+			attribute.Int("server.port", 443),
+			attribute.String("service.peer.name", m.peer),
+			attribute.Int("http.response.status_code", 200),
 		),
 	)
 	return ctx, span
@@ -280,21 +294,23 @@ func chatSpan(ctx context.Context, m modelInfo, inputTokens, outputTokens int, f
 
 // embeddingSpan creates an "embedding {model}" span for text-to-vector operations.
 func embeddingSpan(ctx context.Context, m modelInfo, inputTokens, dimensions int) (context.Context, trace.Span) {
-	ctx, span := tracer("llm-gateway").Start(ctx, "embedding "+m.name,
+	ctx, span := tracer("llm-gateway").Start(ctx, "embeddings "+m.name,
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("gen_ai.operation.name", "embedding"),
-			attribute.String("gen_ai.system", m.system),
+			attribute.String("gen_ai.operation.name", "embeddings"),
+			attribute.String("gen_ai.provider.name", m.system),
 			attribute.String("gen_ai.request.model", m.name),
 			attribute.String("gen_ai.response.model", m.name),
 			attribute.Int("gen_ai.usage.input_tokens", inputTokens),
 			attribute.Int("gen_ai.embedding.dimension", dimensions),
 			attribute.StringSlice("gen_ai.request.encoding_formats", []string{"float"}),
 			attribute.String("gen_ai.response.id", "embd-"+randomHex(24)),
-			attribute.String("http.method", "POST"),
-			attribute.String("http.url", m.endpoint),
-			attribute.String("peer.service", m.peer),
-			attribute.Int("http.status_code", 200),
+			attribute.String("http.request.method", "POST"),
+			attribute.String("url.full", m.endpoint),
+			attribute.String("server.address", urlHost(m.endpoint)),
+			attribute.Int("server.port", 443),
+			attribute.String("service.peer.name", m.peer),
+			attribute.Int("http.response.status_code", 200),
 		),
 	)
 	return ctx, span
@@ -307,7 +323,7 @@ func agentSpan(ctx context.Context, agentName, agentID, description, sessionID s
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
 			attribute.String("gen_ai.operation.name", "invoke_agent"),
-			attribute.String("gen_ai.system", m.system),
+			attribute.String("gen_ai.provider.name", m.system),
 			attribute.String("gen_ai.agent.id", agentID),
 			attribute.String("gen_ai.agent.name", agentName),
 			attribute.String("gen_ai.agent.description", description),

--- a/cmd/snowglobe/metrics.go
+++ b/cmd/snowglobe/metrics.go
@@ -182,6 +182,11 @@ func newMeterProvider(ctx context.Context, key, serviceName, instanceID, hostNam
 // newServiceMetrics creates every instrument against a meter. Split out from
 // newMeterProvider so tests can drive it with a manual reader instead of an OTLP
 // exporter, and assert on what the derivation actually produces.
+// connectionPoolName is the value for the Required db.client.connection.pool.name
+// dimension. Each simulated service has exactly one pool and its series are already
+// scoped by the service.name resource attribute, so a constant costs no cardinality.
+const connectionPoolName = "default"
+
 func newServiceMetrics(meter metric.Meter) *serviceMetrics {
 	var err error
 	sm := &serviceMetrics{queueDepth: map[string]*atomic.Int64{}}
@@ -261,13 +266,16 @@ func registerObservables(meter metric.Meter, sm *serviceMetrics) {
 		fatal("failed to create cpu gauge", "err", err)
 	}
 
-	mem, err := meter.Int64ObservableGauge(
+	// UpDownCounter, not Gauge: the registry defines system.memory.usage as
+	// instrument: updowncounter, which is a different point kind on the wire.
+	// Reusing the reserved name with a gauge contract is the defect this fixes.
+	mem, err := meter.Int64ObservableUpDownCounter(
 		"system.memory.usage",
 		metric.WithUnit("By"),
 		metric.WithDescription("Simulated resident memory."),
 	)
 	if err != nil {
-		fatal("failed to create memory gauge", "err", err)
+		fatal("failed to create memory usage counter", "err", err)
 	}
 
 	pool, err := meter.Int64ObservableUpDownCounter(
@@ -295,7 +303,8 @@ func registerObservables(meter metric.Meter, sm *serviceMetrics) {
 		if util > 0.98 {
 			util = 0.98
 		}
-		o.ObserveFloat64(cpu, util)
+		o.ObserveFloat64(cpu, util, metric.WithAttributes(
+			attribute.String("cpu.mode", "user")))
 
 		// Memory drifts with load and leaks back down, staying inside a band so
 		// the series looks alive without wandering off.
@@ -307,16 +316,19 @@ func registerObservables(meter metric.Meter, sm *serviceMetrics) {
 		case next > 900<<20:
 			sm.memoryBytes.Store(900 << 20)
 		}
-		o.ObserveInt64(mem, sm.memoryBytes.Load())
+		o.ObserveInt64(mem, sm.memoryBytes.Load(), metric.WithAttributes(
+			attribute.String("system.memory.state", "used")))
 
 		used := sm.inFlightDB.Load()
 		if used > 20 {
 			used = 20
 		}
 		o.ObserveInt64(pool, used, metric.WithAttributes(
-			attribute.String("db.client.connection.state", "used")))
+			attribute.String("db.client.connection.state", "used"),
+			attribute.String("db.client.connection.pool.name", connectionPoolName)))
 		o.ObserveInt64(pool, 20-used, metric.WithAttributes(
-			attribute.String("db.client.connection.state", "idle")))
+			attribute.String("db.client.connection.state", "idle"),
+			attribute.String("db.client.connection.pool.name", connectionPoolName)))
 
 		sm.queueMu.Lock()
 		for dest, depth := range sm.queueDepth {
@@ -359,7 +371,8 @@ func (p metricSpanProcessor) OnStart(_ context.Context, s sdktrace.ReadWriteSpan
 	}
 	if s.SpanKind() == trace.SpanKindServer {
 		sm.activeRequests.Add(context.Background(), 1, metric.WithAttributes(
-			semconv.HTTPRequestMethodKey.String(spanMethod(s.Attributes()))))
+			semconv.HTTPRequestMethodKey.String(spanMethod(s.Attributes())),
+			semconv.URLSchemeKey.String("https")))
 	}
 }
 
@@ -379,7 +392,8 @@ func (p metricSpanProcessor) OnEnd(s sdktrace.ReadOnlySpan) {
 
 	if s.SpanKind() == trace.SpanKindServer {
 		sm.activeRequests.Add(context.Background(), -1, metric.WithAttributes(
-			semconv.HTTPRequestMethodKey.String(spanMethod(attrs))))
+			semconv.HTTPRequestMethodKey.String(spanMethod(attrs)),
+			semconv.URLSchemeKey.String("https")))
 		recordServerRequest(sm, s, attrs)
 	}
 
@@ -407,7 +421,7 @@ func recordServerRequest(sm *serviceMetrics, s sdktrace.ReadOnlySpan, attrs []at
 		semconv.URLSchemeKey.String("https"),
 		semconv.HTTPRouteKey.String(route),
 	}
-	if code := attrInt(attrs, "http.status_code"); code != 0 {
+	if code := attrInt(attrs, "http.response.status_code"); code != 0 {
 		set = append(set, semconv.HTTPResponseStatusCodeKey.Int(code))
 	}
 	if s.Status().Code == codes.Error {
@@ -421,7 +435,7 @@ func recordServerRequest(sm *serviceMetrics, s sdktrace.ReadOnlySpan, attrs []at
 
 // trackDatabase keeps the simulated pool occupancy tied to real db span volume.
 func trackDatabase(sm *serviceMetrics, attrs []attribute.KeyValue) {
-	if attrValue(attrs, "db.system") == "" {
+	if attrValue(attrs, "db.system.name") == "" {
 		return
 	}
 	sm.inFlightDB.Add(1)
@@ -436,14 +450,14 @@ func trackDatabase(sm *serviceMetrics, attrs []attribute.KeyValue) {
 // what makes -no-consumers show up as an unbounded backlog: the publish spans
 // keep arriving and the receive spans stop.
 func trackMessaging(sm *serviceMetrics, s sdktrace.ReadOnlySpan, attrs []attribute.KeyValue) {
-	dest := attrValue(attrs, "messaging.destination")
+	dest := attrValue(attrs, "messaging.destination.name")
 	if dest == "" {
 		return
 	}
 	switch {
-	case attrValue(attrs, "messaging.operation") == "publish", s.SpanKind() == trace.SpanKindProducer:
+	case attrValue(attrs, "messaging.operation.type") == "send", s.SpanKind() == trace.SpanKindProducer:
 		sm.queueFor(dest).Add(1)
-	case attrValue(attrs, "messaging.operation") == "receive", s.SpanKind() == trace.SpanKindConsumer:
+	case attrValue(attrs, "messaging.operation.type") == "process", s.SpanKind() == trace.SpanKindConsumer:
 		if d := sm.queueFor(dest); d.Load() > 0 {
 			d.Add(-1)
 		}
@@ -466,7 +480,7 @@ func trackGenAI(sm *serviceMetrics, s sdktrace.ReadOnlySpan, attrs []attribute.K
 
 	base := []attribute.KeyValue{
 		attribute.String("gen_ai.operation.name", operation),
-		attribute.String("gen_ai.system", attrValue(attrs, "gen_ai.system")),
+		attribute.String("gen_ai.provider.name", attrValue(attrs, "gen_ai.provider.name")),
 		attribute.String("gen_ai.request.model", attrValue(attrs, "gen_ai.request.model")),
 	}
 
@@ -496,7 +510,7 @@ var knownMethods = map[string]bool{
 }
 
 func spanMethod(attrs []attribute.KeyValue) string {
-	m := attrValue(attrs, "http.method")
+	m := attrValue(attrs, "http.request.method")
 	if m == "" {
 		return "_OTHER"
 	}

--- a/cmd/snowglobe/metrics_test.go
+++ b/cmd/snowglobe/metrics_test.go
@@ -21,12 +21,12 @@ func TestSpanMethodBoundsTheLabel(t *testing.T) {
 		attrs []attribute.KeyValue
 		want  string
 	}{
-		{"known verb", []attribute.KeyValue{attribute.String("http.method", "GET")}, "GET"},
-		{"another known verb", []attribute.KeyValue{attribute.String("http.method", "PATCH")}, "PATCH"},
-		{"unknown verb", []attribute.KeyValue{attribute.String("http.method", "FROBNICATE")}, "_OTHER"},
-		{"injection attempt", []attribute.KeyValue{attribute.String("http.method", "' OR 1=1")}, "_OTHER"},
+		{"known verb", []attribute.KeyValue{attribute.String("http.request.method", "GET")}, "GET"},
+		{"another known verb", []attribute.KeyValue{attribute.String("http.request.method", "PATCH")}, "PATCH"},
+		{"unknown verb", []attribute.KeyValue{attribute.String("http.request.method", "FROBNICATE")}, "_OTHER"},
+		{"injection attempt", []attribute.KeyValue{attribute.String("http.request.method", "' OR 1=1")}, "_OTHER"},
 		{"absent", nil, "_OTHER"},
-		{"empty", []attribute.KeyValue{attribute.String("http.method", "")}, "_OTHER"},
+		{"empty", []attribute.KeyValue{attribute.String("http.request.method", "")}, "_OTHER"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -40,7 +40,7 @@ func TestSpanMethodBoundsTheLabel(t *testing.T) {
 func TestSpanMethodIsCaseSensitiveToTheAllowlist(t *testing.T) {
 	// Tracegen emits uppercase verbs. A lowercase one is not silently accepted:
 	// letting case through would double the series for every route.
-	attrs := []attribute.KeyValue{attribute.String("http.method", "get")}
+	attrs := []attribute.KeyValue{attribute.String("http.request.method", "get")}
 	if got := spanMethod(attrs); got != "_OTHER" {
 		t.Fatalf("spanMethod(get) = %q, want _OTHER", got)
 	}
@@ -49,8 +49,8 @@ func TestSpanMethodIsCaseSensitiveToTheAllowlist(t *testing.T) {
 func TestAttrValue(t *testing.T) {
 	attrs := []attribute.KeyValue{
 		attribute.String("http.route", "/users/{id}"),
-		attribute.String("db.system", "postgresql"),
-		attribute.Int("http.status_code", 200),
+		attribute.String("db.system.name", "postgresql"),
+		attribute.Int("http.response.status_code", 200),
 	}
 	if got := attrValue(attrs, "http.route"); got != "/users/{id}" {
 		t.Fatalf("attrValue(http.route) = %q", got)
@@ -61,8 +61,8 @@ func TestAttrValue(t *testing.T) {
 }
 
 func TestAttrInt(t *testing.T) {
-	attrs := []attribute.KeyValue{attribute.Int("http.status_code", 503)}
-	if got := attrInt(attrs, "http.status_code"); got != 503 {
+	attrs := []attribute.KeyValue{attribute.Int("http.response.status_code", 503)}
+	if got := attrInt(attrs, "http.response.status_code"); got != 503 {
 		t.Fatalf("attrInt = %d, want 503", got)
 	}
 	// Absent returns the zero value, which recordServerRequest treats as "no
@@ -193,9 +193,9 @@ func TestServerSpanDerivesRequestDuration(t *testing.T) {
 	_, span := tp.Tracer("t").Start(context.Background(), "POST /api/v2/orders",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
+			attribute.String("http.request.method", "POST"),
 			attribute.String("http.route", "/api/v2/orders"),
-			attribute.Int("http.status_code", 200),
+			attribute.Int("http.response.status_code", 200),
 			attribute.String("user.id", "usr_000123"), // must NOT reach the metric
 		))
 	span.End()
@@ -258,7 +258,7 @@ func TestSpanWithoutTemplatedRouteIsNotRecorded(t *testing.T) {
 		sdktrace.WithSpanProcessor(metricSpanProcessor{key: "svc-no-route"}))
 	_, span := tp.Tracer("t").Start(context.Background(), "GET /orders/12345",
 		trace.WithSpanKind(trace.SpanKindServer),
-		trace.WithAttributes(attribute.String("http.method", "GET")))
+		trace.WithAttributes(attribute.String("http.request.method", "GET")))
 	span.End()
 
 	var rm metricdata.ResourceMetrics
@@ -281,11 +281,15 @@ func TestMessagingSpansMoveQueueDepth(t *testing.T) {
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithSpanProcessor(metricSpanProcessor{key: "svc-messaging"}))
 
+	// name is the free-text system verb; type is the registered enum the
+	// derivation classifies on (send/process, not publish/receive).
 	emit := func(op string) {
+		opType := map[string]string{"publish": "send", "receive": "process"}[op]
 		_, s := tp.Tracer("t").Start(context.Background(), "msg",
 			trace.WithAttributes(
-				attribute.String("messaging.destination", "orders.created"),
-				attribute.String("messaging.operation", op)))
+				attribute.String("messaging.destination.name", "orders.created"),
+				attribute.String("messaging.operation.name", op),
+				attribute.String("messaging.operation.type", opType)))
 		s.End()
 	}
 
@@ -318,7 +322,7 @@ func TestGenAISpanDerivesTokenUsage(t *testing.T) {
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
 			attribute.String("gen_ai.operation.name", "chat"),
-			attribute.String("gen_ai.system", "openai"),
+			attribute.String("gen_ai.provider.name", "openai"),
 			attribute.String("gen_ai.request.model", "gpt-5.4"),
 			attribute.Int("gen_ai.usage.input_tokens", 1200),
 			attribute.Int("gen_ai.usage.output_tokens", 340),

--- a/cmd/snowglobe/scenarios.go
+++ b/cmd/snowglobe/scenarios.go
@@ -17,9 +17,11 @@ func createOrderFlow(ctx context.Context) {
 	ctx, ui := tracer("web-frontend").Start(ctx, "PlaceOrder",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
-			attribute.String("http.url", "/api/v2/orders"),
-			attribute.String("browser.page", "/checkout"),
+			attribute.String("http.request.method", "POST"),
+			attribute.String("url.full", "https://shop.example.com/api/v2/orders"),
+			attribute.String("server.address", "shop.example.com"),
+			attribute.Int("server.port", 443),
+			attribute.String("tracegen.browser.page", "/checkout"),
 			attribute.String("user.session_id", randomUserID()),
 		),
 	)
@@ -29,16 +31,16 @@ func createOrderFlow(ctx context.Context) {
 	ctx, gateway := tracer("api-gateway").Start(ctx, "POST /api/v2/orders",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
+			attribute.String("http.request.method", "POST"),
 			attribute.String("http.route", "/api/v2/orders"),
-			attribute.Int("http.status_code", 200),
-			attribute.String("http.user_agent", "Mozilla/5.0"),
-			attribute.String("net.peer.ip", randomIP()),
+			attribute.Int("http.response.status_code", 200),
+			attribute.String("user_agent.original", "Mozilla/5.0"),
+			attribute.String("network.peer.address", randomIP()),
 		),
 	)
 	defer gateway.End()
 	emitLog(ctx, "api-gateway", logapi.SeverityInfo, "Incoming request POST /api/v2/orders",
-		logapi.String("http.method", "POST"), logapi.String("http.route", "/api/v2/orders"))
+		logapi.String("http.request.method", "POST"), logapi.String("http.route", "/api/v2/orders"))
 	sleep(10, 30)
 
 	// Auth check
@@ -58,9 +60,9 @@ func createOrderFlow(ctx context.Context) {
 	_, cache := tracer("cache-service").Start(ctx, "Redis GET user-session",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "redis"),
-			attribute.String("db.operation", "GET"),
-			attribute.String("db.redis.key", "session:"+randomUserID()),
+			attribute.String("db.system.name", "redis"),
+			attribute.String("db.operation.name", "GET"),
+			attribute.String("tracegen.redis.key", "session:"+randomUserID()),
 			attribute.Bool("cache.hit", !errorChance(0.3)),
 		),
 	)
@@ -86,10 +88,10 @@ func createOrderFlow(ctx context.Context) {
 	_, dbWrite := tracer("order-service").Start(ctx2, "INSERT orders",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "postgresql"),
-			attribute.String("db.operation", "INSERT"),
-			attribute.String("db.name", "orders_db"),
-			attribute.String("db.statement", "INSERT INTO orders (id, user_id, total) VALUES ($1, $2, $3)"),
+			attribute.String("db.system.name", "postgresql"),
+			attribute.String("db.operation.name", "INSERT"),
+			attribute.String("db.namespace", "orders_db"),
+			attribute.String("db.query.text", "INSERT INTO orders (id, user_id, total) VALUES ($1, $2, $3)"),
 		),
 	)
 	sleep(5, 25)
@@ -99,15 +101,16 @@ func createOrderFlow(ctx context.Context) {
 	}
 	dbWrite.End()
 	emitLog(ctx2, "order-service", logapi.SeverityInfo, "Order created successfully",
-		logapi.String("db.operation", "INSERT"))
+		logapi.String("db.operation.name", "INSERT"))
 
 	// Publish to queue
-	_, publish := tracer("order-service").Start(ctx2, "rabbitmq publish orders.created",
+	_, publish := tracer("order-service").Start(ctx2, "publish orders.created",
 		trace.WithSpanKind(trace.SpanKindProducer),
 		trace.WithAttributes(
 			attribute.String("messaging.system", "rabbitmq"),
-			attribute.String("messaging.operation", "publish"),
-			attribute.String("messaging.destination", "orders.created"),
+			attribute.String("messaging.operation.name", "publish"),
+			attribute.String("messaging.operation.type", "send"),
+			attribute.String("messaging.destination.name", "orders.created"),
 		),
 	)
 	sleep(2, 8)
@@ -131,10 +134,11 @@ func createOrderFlow(ctx context.Context) {
 		trace.WithSpanKind(trace.SpanKindConsumer),
 		trace.WithAttributes(
 			attribute.String("messaging.system", "rabbitmq"),
-			attribute.String("messaging.operation", "receive"),
+			attribute.String("messaging.operation.name", "receive"),
+			attribute.String("messaging.operation.type", "process"),
 			// Consume the queue the producer actually published (orders.created),
 			// so producer/consumer correlate and no phantom is raised.
-			attribute.String("messaging.destination", "orders.created"),
+			attribute.String("messaging.destination.name", "orders.created"),
 			attribute.String("payment.provider", "stripe"),
 		),
 	)
@@ -146,9 +150,9 @@ func createOrderFlow(ctx context.Context) {
 	_, payCache := tracer("cache-service").Start(ctx3, "Redis GET payment-idempotency",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "redis"),
-			attribute.String("db.operation", "GET"),
-			attribute.String("db.redis.key", "idempotent:"+randomOrderID()),
+			attribute.String("db.system.name", "redis"),
+			attribute.String("db.operation.name", "GET"),
+			attribute.String("tracegen.redis.key", "idempotent:"+randomOrderID()),
 		),
 	)
 	sleep(1, 3)
@@ -158,10 +162,12 @@ func createOrderFlow(ctx context.Context) {
 	_, stripe := tracer("payment-service").Start(ctx3, "POST https://api.stripe.com/v1/charges",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
-			attribute.String("http.url", "https://api.stripe.com/v1/charges"),
-			attribute.String("peer.service", "stripe-api"),
-			attribute.Int("http.status_code", 200),
+			attribute.String("http.request.method", "POST"),
+			attribute.String("url.full", "https://api.stripe.com/v1/charges"),
+			attribute.String("server.address", "api.stripe.com"),
+			attribute.Int("server.port", 443),
+			attribute.String("service.peer.name", "stripe-api"),
+			attribute.Int("http.response.status_code", 200),
 		),
 	)
 	sleep(80, 300)
@@ -182,8 +188,9 @@ func createOrderFlow(ctx context.Context) {
 		trace.WithSpanKind(trace.SpanKindConsumer),
 		trace.WithAttributes(
 			attribute.String("messaging.system", "rabbitmq"),
-			attribute.String("messaging.operation", "receive"),
-			attribute.String("messaging.destination", "inventory.reserve"),
+			attribute.String("messaging.operation.name", "receive"),
+			attribute.String("messaging.operation.type", "process"),
+			attribute.String("messaging.destination.name", "inventory.reserve"),
 		),
 	)
 	sleep(30, 80)
@@ -191,9 +198,9 @@ func createOrderFlow(ctx context.Context) {
 	_, dbUpdate := tracer("inventory-service").Start(ctx4, "UPDATE inventory SET quantity = quantity - $1",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "postgresql"),
-			attribute.String("db.operation", "UPDATE"),
-			attribute.String("db.name", "inventory_db"),
+			attribute.String("db.system.name", "postgresql"),
+			attribute.String("db.operation.name", "UPDATE"),
+			attribute.String("db.namespace", "inventory_db"),
 		),
 	)
 	sleep(10, 40)
@@ -213,9 +220,10 @@ func createOrderFlow(ctx context.Context) {
 		trace.WithSpanKind(trace.SpanKindConsumer),
 		trace.WithAttributes(
 			attribute.String("messaging.system", "kafka"),
-			attribute.String("messaging.operation", "receive"),
-			attribute.String("messaging.destination", "notifications.email"),
-			attribute.String("peer.service", "sendgrid"),
+			attribute.String("messaging.operation.name", "receive"),
+			attribute.String("messaging.operation.type", "process"),
+			attribute.String("messaging.destination.name", "notifications.email"),
+			attribute.String("service.peer.name", "sendgrid"),
 			attribute.String("notification.type", "order_confirmation"),
 		),
 	)
@@ -228,9 +236,11 @@ func searchAndBrowseFlow(ctx context.Context) {
 	ctx, ui := tracer("web-frontend").Start(ctx, "SearchProducts",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("http.method", "GET"),
-			attribute.String("http.url", "/api/v2/search"),
-			attribute.String("browser.page", "/search"),
+			attribute.String("http.request.method", "GET"),
+			attribute.String("url.full", "https://shop.example.com/api/v2/search"),
+			attribute.String("server.address", "shop.example.com"),
+			attribute.Int("server.port", 443),
+			attribute.String("tracegen.browser.page", "/search"),
 			attribute.String("search.query", randomSearchTerm()),
 		),
 	)
@@ -240,9 +250,9 @@ func searchAndBrowseFlow(ctx context.Context) {
 	ctx, gateway := tracer("api-gateway").Start(ctx, "GET /api/v2/search",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String("http.method", "GET"),
+			attribute.String("http.request.method", "GET"),
 			attribute.String("http.route", "/api/v2/search"),
-			attribute.Int("http.status_code", 200),
+			attribute.Int("http.response.status_code", 200),
 			attribute.String("search.query", randomSearchTerm()),
 		),
 	)
@@ -253,8 +263,8 @@ func searchAndBrowseFlow(ctx context.Context) {
 	_, cache := tracer("cache-service").Start(ctx, "Redis GET search-cache",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "redis"),
-			attribute.String("db.operation", "GET"),
+			attribute.String("db.system.name", "redis"),
+			attribute.String("db.operation.name", "GET"),
 			attribute.Bool("cache.hit", false),
 		),
 	)
@@ -265,8 +275,8 @@ func searchAndBrowseFlow(ctx context.Context) {
 	ctx2, search := tracer("search-service").Start(ctx, "Elasticsearch Query",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String("db.system", "elasticsearch"),
-			attribute.String("db.operation", "search"),
+			attribute.String("db.system.name", "elasticsearch"),
+			attribute.String("db.operation.name", "search"),
 			attribute.Int("search.results_count", rand.Intn(50)),
 		),
 	)
@@ -275,8 +285,8 @@ func searchAndBrowseFlow(ctx context.Context) {
 	_, esQuery := tracer("search-service").Start(ctx2, "POST /products/_search",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
-			attribute.String("db.statement", `{"query":{"match":{"name":"widget"}}}`),
+			attribute.String("http.request.method", "POST"),
+			attribute.String("db.query.text", `{"query":{"match":{"name":"widget"}}}`),
 		),
 	)
 	sleep(20, 80)
@@ -291,9 +301,9 @@ func searchAndBrowseFlow(ctx context.Context) {
 	_, cacheSet := tracer("cache-service").Start(ctx, "Redis SET search-cache",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "redis"),
-			attribute.String("db.operation", "SET"),
-			attribute.Int("db.redis.ttl_seconds", 300),
+			attribute.String("db.system.name", "redis"),
+			attribute.String("db.operation.name", "SET"),
+			attribute.Int("tracegen.redis.ttl_seconds", 300),
 		),
 	)
 	sleep(1, 3)
@@ -307,9 +317,11 @@ func userLoginFlow(ctx context.Context) {
 	ctx, ui := tracer("web-frontend").Start(ctx, "UserLogin",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
-			attribute.String("http.url", "/api/v2/auth/login"),
-			attribute.String("browser.page", "/login"),
+			attribute.String("http.request.method", "POST"),
+			attribute.String("url.full", "https://shop.example.com/api/v2/auth/login"),
+			attribute.String("server.address", "shop.example.com"),
+			attribute.Int("server.port", 443),
+			attribute.String("tracegen.browser.page", "/login"),
 		),
 	)
 	defer ui.End()
@@ -318,16 +330,16 @@ func userLoginFlow(ctx context.Context) {
 	ctx, gateway := tracer("api-gateway").Start(ctx, "POST /api/v2/auth/login",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
+			attribute.String("http.request.method", "POST"),
 			attribute.String("http.route", "/api/v2/auth/login"),
 		),
 	)
 	defer func() {
 		if isFailure {
-			gateway.SetAttributes(attribute.Int("http.status_code", 401))
+			gateway.SetAttributes(attribute.Int("http.response.status_code", 401))
 			gateway.SetStatus(codes.Error, "authentication failed")
 		} else {
-			gateway.SetAttributes(attribute.Int("http.status_code", 200))
+			gateway.SetAttributes(attribute.Int("http.response.status_code", 200))
 		}
 		gateway.End()
 	}()
@@ -347,9 +359,9 @@ func userLoginFlow(ctx context.Context) {
 	_, dbLookup := tracer("user-service").Start(ctx2, "SELECT users WHERE email = $1",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "postgresql"),
-			attribute.String("db.operation", "SELECT"),
-			attribute.String("db.name", "users_db"),
+			attribute.String("db.system.name", "postgresql"),
+			attribute.String("db.operation.name", "SELECT"),
+			attribute.String("db.namespace", "users_db"),
 		),
 	)
 	sleep(5, 20)
@@ -369,10 +381,10 @@ func userLoginFlow(ctx context.Context) {
 	_, session := tracer("cache-service").Start(ctx, "Redis SET user-session",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "redis"),
-			attribute.String("db.operation", "SET"),
-			attribute.String("db.redis.key", "session:"+randomUserID()),
-			attribute.Int("db.redis.ttl_seconds", 3600),
+			attribute.String("db.system.name", "redis"),
+			attribute.String("db.operation.name", "SET"),
+			attribute.String("tracegen.redis.key", "session:"+randomUserID()),
+			attribute.Int("tracegen.redis.ttl_seconds", 3600),
 		),
 	)
 	sleep(1, 3)
@@ -384,9 +396,11 @@ func failedPaymentFlow(ctx context.Context) {
 	ctx, ui := tracer("web-frontend").Start(ctx, "PlaceOrder",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
-			attribute.String("http.url", "/api/v2/orders"),
-			attribute.String("browser.page", "/checkout"),
+			attribute.String("http.request.method", "POST"),
+			attribute.String("url.full", "https://shop.example.com/api/v2/orders"),
+			attribute.String("server.address", "shop.example.com"),
+			attribute.Int("server.port", 443),
+			attribute.String("tracegen.browser.page", "/checkout"),
 		),
 	)
 	defer ui.End()
@@ -395,10 +409,10 @@ func failedPaymentFlow(ctx context.Context) {
 	ctx, gateway := tracer("api-gateway").Start(ctx, "POST /api/v2/orders",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
+			attribute.String("http.request.method", "POST"),
 			attribute.String("http.route", "/api/v2/orders"),
-			attribute.Int("http.status_code", 402),
-			attribute.String("net.peer.ip", randomIP()),
+			attribute.Int("http.response.status_code", 402),
+			attribute.String("network.peer.address", randomIP()),
 		),
 	)
 	exc := randomException(paymentExceptions)
@@ -419,8 +433,8 @@ func failedPaymentFlow(ctx context.Context) {
 	_, dbWrite := tracer("order-service").Start(ctx2, "INSERT orders",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "postgresql"),
-			attribute.String("db.operation", "INSERT"),
+			attribute.String("db.system.name", "postgresql"),
+			attribute.String("db.operation.name", "INSERT"),
 		),
 	)
 	sleep(5, 15)
@@ -448,9 +462,9 @@ func failedPaymentFlow(ctx context.Context) {
 	_, stripe := tracer("payment-service").Start(ctx3, "POST https://api.stripe.com/v1/charges",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
-			attribute.String("peer.service", "stripe-api"),
-			attribute.Int("http.status_code", 402),
+			attribute.String("http.request.method", "POST"),
+			attribute.String("service.peer.name", "stripe-api"),
+			attribute.Int("http.response.status_code", 402),
 			attribute.String("error.type", "card_declined"),
 		),
 	)
@@ -466,7 +480,7 @@ func failedPaymentFlow(ctx context.Context) {
 	_, notify := tracer("notification-service").Start(ctx, "SendPaymentFailedEmail",
 		trace.WithSpanKind(trace.SpanKindConsumer),
 		trace.WithAttributes(
-			attribute.String("peer.service", "sendgrid"),
+			attribute.String("service.peer.name", "sendgrid"),
 			attribute.String("notification.type", "payment_failed"),
 		),
 	)
@@ -479,9 +493,11 @@ func bulkNotificationFlow(ctx context.Context) {
 	ctx, ui := tracer("web-frontend").Start(ctx, "TriggerDigest",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
-			attribute.String("http.url", "/api/v2/admin/digest"),
-			attribute.String("browser.page", "/admin/notifications"),
+			attribute.String("http.request.method", "POST"),
+			attribute.String("url.full", "https://shop.example.com/api/v2/admin/digest"),
+			attribute.String("server.address", "shop.example.com"),
+			attribute.Int("server.port", 443),
+			attribute.String("tracegen.browser.page", "/admin/notifications"),
 		),
 	)
 	defer ui.End()
@@ -490,9 +506,9 @@ func bulkNotificationFlow(ctx context.Context) {
 	ctx, gateway := tracer("api-gateway").Start(ctx, "POST /api/v2/admin/digest",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
+			attribute.String("http.request.method", "POST"),
 			attribute.String("http.route", "/api/v2/admin/digest"),
-			attribute.Int("http.status_code", 202),
+			attribute.Int("http.response.status_code", 202),
 		),
 	)
 	defer gateway.End()
@@ -512,22 +528,23 @@ func bulkNotificationFlow(ctx context.Context) {
 	_, dbRead := tracer("order-service").Start(ctx, "SELECT pending_notifications",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "postgresql"),
-			attribute.String("db.operation", "SELECT"),
-			attribute.String("db.statement", "SELECT * FROM notifications WHERE status = 'pending' LIMIT 100"),
+			attribute.String("db.system.name", "postgresql"),
+			attribute.String("db.operation.name", "SELECT"),
+			attribute.String("db.query.text", "SELECT * FROM notifications WHERE status = 'pending' LIMIT 100"),
 		),
 	)
 	sleep(15, 50)
 	dbRead.End()
 
 	// Publish to notification queue
-	_, publish := tracer("order-service").Start(ctx, "rabbitmq publish notifications.digest",
+	_, publish := tracer("order-service").Start(ctx, "publish notifications.digest",
 		trace.WithSpanKind(trace.SpanKindProducer),
 		trace.WithAttributes(
 			attribute.String("messaging.system", "rabbitmq"),
-			attribute.String("messaging.operation", "publish"),
-			attribute.String("messaging.destination", "notifications.digest"),
-			attribute.Int("messaging.batch_size", 3+rand.Intn(3)),
+			attribute.String("messaging.operation.name", "publish"),
+			attribute.String("messaging.operation.type", "send"),
+			attribute.String("messaging.destination.name", "notifications.digest"),
+			attribute.Int("messaging.batch.message_count", 3+rand.Intn(3)),
 		),
 	)
 	sleep(2, 8)
@@ -548,9 +565,10 @@ func bulkNotificationFlow(ctx context.Context) {
 			trace.WithAttributes(
 				// Correlate with the notifications.digest producer above.
 				attribute.String("messaging.system", "rabbitmq"),
-				attribute.String("messaging.operation", "receive"),
-				attribute.String("messaging.destination", "notifications.digest"),
-				attribute.String("peer.service", "sendgrid"),
+				attribute.String("messaging.operation.name", "receive"),
+				attribute.String("messaging.operation.type", "process"),
+				attribute.String("messaging.destination.name", "notifications.digest"),
+				attribute.String("service.peer.name", "sendgrid"),
 				attribute.String("notification.type", "daily_digest"),
 				attribute.Int("notification.batch_index", i),
 			),
@@ -570,9 +588,11 @@ func healthCheckFlow(ctx context.Context) {
 	ctx, ui := tracer("web-frontend").Start(ctx, "HealthDashboard",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("http.method", "GET"),
-			attribute.String("http.url", "/api/v2/healthz"),
-			attribute.String("browser.page", "/admin/health"),
+			attribute.String("http.request.method", "GET"),
+			attribute.String("url.full", "https://shop.example.com/api/v2/healthz"),
+			attribute.String("server.address", "shop.example.com"),
+			attribute.Int("server.port", 443),
+			attribute.String("tracegen.browser.page", "/admin/health"),
 		),
 	)
 	defer ui.End()
@@ -581,9 +601,9 @@ func healthCheckFlow(ctx context.Context) {
 	ctx, gateway := tracer("api-gateway").Start(ctx, "GET /healthz",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String("http.method", "GET"),
+			attribute.String("http.request.method", "GET"),
 			attribute.String("http.route", "/healthz"),
-			attribute.Int("http.status_code", 200),
+			attribute.Int("http.response.status_code", 200),
 		),
 	)
 	defer gateway.End()
@@ -631,9 +651,11 @@ func inventorySyncFlow(ctx context.Context) {
 	ctx, ui := tracer("web-frontend").Start(ctx, "TriggerInventorySync",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
-			attribute.String("http.url", "/api/v2/admin/inventory/sync"),
-			attribute.String("browser.page", "/admin/inventory"),
+			attribute.String("http.request.method", "POST"),
+			attribute.String("url.full", "https://shop.example.com/api/v2/admin/inventory/sync"),
+			attribute.String("server.address", "shop.example.com"),
+			attribute.Int("server.port", 443),
+			attribute.String("tracegen.browser.page", "/admin/inventory"),
 		),
 	)
 	defer ui.End()
@@ -642,9 +664,9 @@ func inventorySyncFlow(ctx context.Context) {
 	ctx, gateway := tracer("api-gateway").Start(ctx, "POST /api/v2/admin/inventory/sync",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
+			attribute.String("http.request.method", "POST"),
 			attribute.String("http.route", "/api/v2/admin/inventory/sync"),
-			attribute.Int("http.status_code", 202),
+			attribute.Int("http.response.status_code", 202),
 		),
 	)
 	defer gateway.End()
@@ -664,10 +686,10 @@ func inventorySyncFlow(ctx context.Context) {
 	_, dbRead := tracer("inventory-service").Start(ctx, "SELECT inventory WHERE updated_at > $1",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "postgresql"),
-			attribute.String("db.operation", "SELECT"),
-			attribute.String("db.name", "inventory_db"),
-			attribute.Int("db.rows_affected", 20+rand.Intn(80)),
+			attribute.String("db.system.name", "postgresql"),
+			attribute.String("db.operation.name", "SELECT"),
+			attribute.String("db.namespace", "inventory_db"),
+			attribute.Int("db.response.returned_rows", 20+rand.Intn(80)),
 		),
 	)
 	sleep(15, 60)
@@ -681,9 +703,9 @@ func inventorySyncFlow(ctx context.Context) {
 			_, cacheSet := tracer("cache-service").Start(ctx, fmt.Sprintf("Redis MSET inventory-batch-%d", i),
 				trace.WithSpanKind(trace.SpanKindClient),
 				trace.WithAttributes(
-					attribute.String("db.system", "redis"),
-					attribute.String("db.operation", "MSET"),
-					attribute.Int("db.redis.keys_count", 5+rand.Intn(15)),
+					attribute.String("db.system.name", "redis"),
+					attribute.String("db.operation.name", "MSET"),
+					attribute.Int("tracegen.redis.keys_count", 5+rand.Intn(15)),
 				),
 			)
 			sleep(2, 8)
@@ -699,9 +721,9 @@ func inventorySyncFlow(ctx context.Context) {
 	_, reindex := tracer("search-service").Start(ctx, "POST /products/_bulk",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "elasticsearch"),
-			attribute.String("db.operation", "bulk_index"),
-			attribute.Int("db.docs_count", 10+rand.Intn(40)),
+			attribute.String("db.system.name", "elasticsearch"),
+			attribute.String("db.operation.name", "bulk_index"),
+			attribute.Int("tracegen.db.docs_count", 10+rand.Intn(40)),
 		),
 	)
 	sleep(30, 120)
@@ -748,10 +770,10 @@ func scheduledReportFlow(ctx context.Context) {
 	_, dbQuery := tracer("order-service").Start(ctx2, "SELECT orders WHERE created_at > $1 GROUP BY status",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "postgresql"),
-			attribute.String("db.operation", "SELECT"),
-			attribute.String("db.name", "orders_db"),
-			attribute.Int("db.rows_affected", 50+rand.Intn(500)),
+			attribute.String("db.system.name", "postgresql"),
+			attribute.String("db.operation.name", "SELECT"),
+			attribute.String("db.namespace", "orders_db"),
+			attribute.Int("db.response.returned_rows", 50+rand.Intn(500)),
 		),
 	)
 	sleep(30, 120)
@@ -774,9 +796,9 @@ func scheduledReportFlow(ctx context.Context) {
 	_, invDB := tracer("inventory-service").Start(ctx3, "SELECT inventory GROUP BY category",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "postgresql"),
-			attribute.String("db.operation", "SELECT"),
-			attribute.String("db.name", "inventory_db"),
+			attribute.String("db.system.name", "postgresql"),
+			attribute.String("db.operation.name", "SELECT"),
+			attribute.String("db.namespace", "inventory_db"),
 		),
 	)
 	sleep(20, 80)
@@ -787,22 +809,23 @@ func scheduledReportFlow(ctx context.Context) {
 	_, cacheSet := tracer("cache-service").Start(ctx, "Redis SET daily-report",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "redis"),
-			attribute.String("db.operation", "SET"),
-			attribute.String("db.redis.key", "report:daily:"+time.Now().Format("2006-01-02")),
-			attribute.Int("db.redis.ttl_seconds", 86400),
+			attribute.String("db.system.name", "redis"),
+			attribute.String("db.operation.name", "SET"),
+			attribute.String("tracegen.redis.key", "report:daily:"+time.Now().Format("2006-01-02")),
+			attribute.Int("tracegen.redis.ttl_seconds", 86400),
 		),
 	)
 	sleep(2, 5)
 	cacheSet.End()
 
 	// Publish report-ready event
-	_, publish := tracer("scheduler-service").Start(ctx, "rabbitmq publish reports.ready",
+	_, publish := tracer("scheduler-service").Start(ctx, "publish reports.ready",
 		trace.WithSpanKind(trace.SpanKindProducer),
 		trace.WithAttributes(
 			attribute.String("messaging.system", "rabbitmq"),
-			attribute.String("messaging.operation", "publish"),
-			attribute.String("messaging.destination", "reports.ready"),
+			attribute.String("messaging.operation.name", "publish"),
+			attribute.String("messaging.operation.type", "send"),
+			attribute.String("messaging.destination.name", "reports.ready"),
 		),
 	)
 	sleep(2, 5)
@@ -819,10 +842,11 @@ func scheduledReportFlow(ctx context.Context) {
 		trace.WithSpanKind(trace.SpanKindConsumer),
 		trace.WithAttributes(
 			attribute.String("messaging.system", "rabbitmq"),
-			attribute.String("messaging.operation", "receive"),
+			attribute.String("messaging.operation.name", "receive"),
+			attribute.String("messaging.operation.type", "process"),
 			// Correlate with the reports.ready producer above.
-			attribute.String("messaging.destination", "reports.ready"),
-			attribute.String("peer.service", "sendgrid"),
+			attribute.String("messaging.destination.name", "reports.ready"),
+			attribute.String("service.peer.name", "sendgrid"),
 			attribute.String("notification.type", "daily_report"),
 		),
 	)
@@ -840,11 +864,11 @@ func stripeWebhookFlow(ctx context.Context) {
 	ctx, webhook := tracer("payment-service").Start(ctx, "POST /webhooks/stripe",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
+			attribute.String("http.request.method", "POST"),
 			attribute.String("http.route", "/webhooks/stripe"),
 			attribute.String("webhook.event", "charge.succeeded"),
 			attribute.String("webhook.id", fmt.Sprintf("evt_%016d", rand.Int63())),
-			attribute.String("peer.service", "stripe-api"),
+			attribute.String("service.peer.name", "stripe-api"),
 		),
 	)
 	defer webhook.End()
@@ -887,9 +911,9 @@ func stripeWebhookFlow(ctx context.Context) {
 	_, dbUpdate := tracer("order-service").Start(ctx2, "UPDATE orders SET status = $1 WHERE stripe_id = $2",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "postgresql"),
-			attribute.String("db.operation", "UPDATE"),
-			attribute.String("db.name", "orders_db"),
+			attribute.String("db.system.name", "postgresql"),
+			attribute.String("db.operation.name", "UPDATE"),
+			attribute.String("db.namespace", "orders_db"),
 		),
 	)
 	sleep(5, 20)
@@ -900,21 +924,22 @@ func stripeWebhookFlow(ctx context.Context) {
 	_, cacheInval := tracer("cache-service").Start(ctx, "Redis DEL order-cache",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "redis"),
-			attribute.String("db.operation", "DEL"),
-			attribute.String("db.redis.key", "order:status:*"),
+			attribute.String("db.system.name", "redis"),
+			attribute.String("db.operation.name", "DEL"),
+			attribute.String("tracegen.redis.key", "order:status:*"),
 		),
 	)
 	sleep(1, 3)
 	cacheInval.End()
 
 	// Publish order-confirmed event
-	_, publish := tracer("payment-service").Start(ctx, "rabbitmq publish orders.confirmed",
+	_, publish := tracer("payment-service").Start(ctx, "publish orders.confirmed",
 		trace.WithSpanKind(trace.SpanKindProducer),
 		trace.WithAttributes(
 			attribute.String("messaging.system", "rabbitmq"),
-			attribute.String("messaging.operation", "publish"),
-			attribute.String("messaging.destination", "orders.confirmed"),
+			attribute.String("messaging.operation.name", "publish"),
+			attribute.String("messaging.operation.type", "send"),
+			attribute.String("messaging.destination.name", "orders.confirmed"),
 		),
 	)
 	sleep(2, 5)
@@ -931,10 +956,11 @@ func stripeWebhookFlow(ctx context.Context) {
 		trace.WithSpanKind(trace.SpanKindConsumer),
 		trace.WithAttributes(
 			attribute.String("messaging.system", "rabbitmq"),
-			attribute.String("messaging.operation", "receive"),
+			attribute.String("messaging.operation.name", "receive"),
+			attribute.String("messaging.operation.type", "process"),
 			// Correlate with the orders.confirmed producer above.
-			attribute.String("messaging.destination", "orders.confirmed"),
-			attribute.String("peer.service", "sendgrid"),
+			attribute.String("messaging.destination.name", "orders.confirmed"),
+			attribute.String("service.peer.name", "sendgrid"),
 			attribute.String("notification.type", "payment_receipt"),
 		),
 	)
@@ -948,9 +974,11 @@ func recommendationFlow(ctx context.Context) {
 	ctx, ui := tracer("web-frontend").Start(ctx, "GetRecommendations",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("http.method", "GET"),
-			attribute.String("http.url", "/api/v2/recommendations"),
-			attribute.String("browser.page", "/products"),
+			attribute.String("http.request.method", "GET"),
+			attribute.String("url.full", "https://shop.example.com/api/v2/recommendations"),
+			attribute.String("server.address", "shop.example.com"),
+			attribute.Int("server.port", 443),
+			attribute.String("tracegen.browser.page", "/products"),
 			attribute.String("user.session_id", randomUserID()),
 		),
 	)
@@ -960,9 +988,9 @@ func recommendationFlow(ctx context.Context) {
 	ctx, gateway := tracer("api-gateway").Start(ctx, "GET /api/v2/recommendations",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String("http.method", "GET"),
+			attribute.String("http.request.method", "GET"),
 			attribute.String("http.route", "/api/v2/recommendations"),
-			attribute.Int("http.status_code", 200),
+			attribute.Int("http.response.status_code", 200),
 		),
 	)
 	defer gateway.End()
@@ -1000,8 +1028,8 @@ func recommendationFlow(ctx context.Context) {
 		_, searchSpan := tracer("search-service").Start(ctx2, "SimilarProducts query",
 			trace.WithSpanKind(trace.SpanKindClient),
 			trace.WithAttributes(
-				attribute.String("db.system", "elasticsearch"),
-				attribute.String("db.operation", "search"),
+				attribute.String("db.system.name", "elasticsearch"),
+				attribute.String("db.operation.name", "search"),
 				attribute.String("search.type", "more_like_this"),
 				attribute.Int("search.results_count", 10+rand.Intn(30)),
 			),
@@ -1020,8 +1048,8 @@ func recommendationFlow(ctx context.Context) {
 		_, invSpan := tracer("inventory-service").Start(ctx2, "CheckAvailability batch",
 			trace.WithSpanKind(trace.SpanKindClient),
 			trace.WithAttributes(
-				attribute.String("db.system", "postgresql"),
-				attribute.String("db.operation", "SELECT"),
+				attribute.String("db.system.name", "postgresql"),
+				attribute.String("db.operation.name", "SELECT"),
 				attribute.Int("batch.size", 20+rand.Intn(30)),
 			),
 		)
@@ -1057,10 +1085,10 @@ func recommendationFlow(ctx context.Context) {
 	_, cacheSet := tracer("cache-service").Start(ctx2, "Redis SET user-recommendations",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "redis"),
-			attribute.String("db.operation", "SET"),
-			attribute.String("db.redis.key", "recs:"+randomUserID()),
-			attribute.Int("db.redis.ttl_seconds", 600),
+			attribute.String("db.system.name", "redis"),
+			attribute.String("db.operation.name", "SET"),
+			attribute.String("tracegen.redis.key", "recs:"+randomUserID()),
+			attribute.Int("tracegen.redis.ttl_seconds", 600),
 		),
 	)
 	sleep(1, 3)
@@ -1072,9 +1100,11 @@ func addToCartFlow(ctx context.Context) {
 	ctx, ui := tracer("web-frontend").Start(ctx, "AddToCart",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
-			attribute.String("http.url", "/api/v2/cart/items"),
-			attribute.String("browser.page", "/products/detail"),
+			attribute.String("http.request.method", "POST"),
+			attribute.String("url.full", "https://shop.example.com/api/v2/cart/items"),
+			attribute.String("server.address", "shop.example.com"),
+			attribute.Int("server.port", 443),
+			attribute.String("tracegen.browser.page", "/products/detail"),
 			attribute.String("user.session_id", randomUserID()),
 		),
 	)
@@ -1084,9 +1114,9 @@ func addToCartFlow(ctx context.Context) {
 	ctx, gateway := tracer("api-gateway").Start(ctx, "POST /api/v2/cart/items",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
+			attribute.String("http.request.method", "POST"),
 			attribute.String("http.route", "/api/v2/cart/items"),
-			attribute.Int("http.status_code", 200),
+			attribute.Int("http.response.status_code", 200),
 		),
 	)
 	defer gateway.End()
@@ -1130,9 +1160,9 @@ func addToCartFlow(ctx context.Context) {
 	_, productDB := tracer("product-service").Start(ctx2, "SELECT products WHERE id = $1",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "postgresql"),
-			attribute.String("db.operation", "SELECT"),
-			attribute.String("db.name", "products_db"),
+			attribute.String("db.system.name", "postgresql"),
+			attribute.String("db.operation.name", "SELECT"),
+			attribute.String("db.namespace", "products_db"),
 		),
 	)
 	sleep(3, 12)
@@ -1146,8 +1176,8 @@ func addToCartFlow(ctx context.Context) {
 	_, productCache := tracer("cache-service").Start(ctx2, "Redis GET product:detail",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "redis"),
-			attribute.String("db.operation", "GET"),
+			attribute.String("db.system.name", "redis"),
+			attribute.String("db.operation.name", "GET"),
 			attribute.Bool("cache.hit", rand.Intn(3) != 0),
 		),
 	)
@@ -1168,9 +1198,9 @@ func addToCartFlow(ctx context.Context) {
 	_, cartStore := tracer("cart-service").Start(ctx3, "Redis HSET cart:user:items",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "redis"),
-			attribute.String("db.operation", "HSET"),
-			attribute.String("db.redis.key", "cart:"+randomUserID()),
+			attribute.String("db.system.name", "redis"),
+			attribute.String("db.operation.name", "HSET"),
+			attribute.String("tracegen.redis.key", "cart:"+randomUserID()),
 		),
 	)
 	sleep(1, 3)
@@ -1182,7 +1212,7 @@ func addToCartFlow(ctx context.Context) {
 		trace.WithSpanKind(trace.SpanKindProducer),
 		trace.WithAttributes(
 			attribute.String("messaging.system", "kafka"),
-			attribute.String("messaging.destination", "analytics.events"),
+			attribute.String("messaging.destination.name", "analytics.events"),
 			attribute.String("analytics.event_type", "cart.item_added"),
 		),
 	)
@@ -1197,8 +1227,9 @@ func addToCartFlow(ctx context.Context) {
 		trace.WithSpanKind(trace.SpanKindConsumer),
 		trace.WithAttributes(
 			attribute.String("messaging.system", "kafka"),
-			attribute.String("messaging.operation", "receive"),
-			attribute.String("messaging.destination", "analytics.events"),
+			attribute.String("messaging.operation.name", "receive"),
+			attribute.String("messaging.operation.type", "process"),
+			attribute.String("messaging.destination.name", "analytics.events"),
 			attribute.String("analytics.event_type", "cart.item_added"),
 		),
 	)
@@ -1213,9 +1244,11 @@ func fullCheckoutFlow(ctx context.Context) {
 	ctx, ui := tracer("web-frontend").Start(ctx, "Checkout",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
-			attribute.String("http.url", "/api/v2/checkout"),
-			attribute.String("browser.page", "/checkout/confirm"),
+			attribute.String("http.request.method", "POST"),
+			attribute.String("url.full", "https://shop.example.com/api/v2/checkout"),
+			attribute.String("server.address", "shop.example.com"),
+			attribute.Int("server.port", 443),
+			attribute.String("tracegen.browser.page", "/checkout/confirm"),
 			attribute.String("user.session_id", randomUserID()),
 		),
 	)
@@ -1225,10 +1258,10 @@ func fullCheckoutFlow(ctx context.Context) {
 	ctx, gateway := tracer("api-gateway").Start(ctx, "POST /api/v2/checkout",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
+			attribute.String("http.request.method", "POST"),
 			attribute.String("http.route", "/api/v2/checkout"),
-			attribute.Int("http.status_code", 200),
-			attribute.String("net.peer.ip", randomIP()),
+			attribute.Int("http.response.status_code", 200),
+			attribute.String("network.peer.address", randomIP()),
 		),
 	)
 	defer gateway.End()
@@ -1262,8 +1295,8 @@ func fullCheckoutFlow(ctx context.Context) {
 	_, cartRead := tracer("cart-service").Start(ctx2, "Redis HGETALL cart:user:items",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "redis"),
-			attribute.String("db.operation", "HGETALL"),
+			attribute.String("db.system.name", "redis"),
+			attribute.String("db.operation.name", "HGETALL"),
 		),
 	)
 	sleep(1, 3)
@@ -1340,9 +1373,9 @@ func fullCheckoutFlow(ctx context.Context) {
 	_, dbInsert := tracer("order-service").Start(ctx3, "INSERT orders",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "postgresql"),
-			attribute.String("db.operation", "INSERT"),
-			attribute.String("db.name", "orders_db"),
+			attribute.String("db.system.name", "postgresql"),
+			attribute.String("db.operation.name", "INSERT"),
+			attribute.String("db.namespace", "orders_db"),
 		),
 	)
 	sleep(5, 20)
@@ -1393,9 +1426,9 @@ func fullCheckoutFlow(ctx context.Context) {
 	_, idemCache := tracer("cache-service").Start(ctx5, "Redis GET payment-idempotency",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "redis"),
-			attribute.String("db.operation", "GET"),
-			attribute.String("db.redis.key", "idempotent:"+orderID),
+			attribute.String("db.system.name", "redis"),
+			attribute.String("db.operation.name", "GET"),
+			attribute.String("tracegen.redis.key", "idempotent:"+orderID),
 		),
 	)
 	sleep(1, 3)
@@ -1404,10 +1437,12 @@ func fullCheckoutFlow(ctx context.Context) {
 	_, stripe := tracer("payment-service").Start(ctx5, "POST https://api.stripe.com/v1/charges",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
-			attribute.String("http.url", "https://api.stripe.com/v1/charges"),
-			attribute.String("peer.service", "stripe-api"),
-			attribute.Int("http.status_code", 200),
+			attribute.String("http.request.method", "POST"),
+			attribute.String("url.full", "https://api.stripe.com/v1/charges"),
+			attribute.String("server.address", "api.stripe.com"),
+			attribute.Int("server.port", 443),
+			attribute.String("service.peer.name", "stripe-api"),
+			attribute.Int("http.response.status_code", 200),
 		),
 	)
 	sleep(80, 300)
@@ -1427,9 +1462,9 @@ func fullCheckoutFlow(ctx context.Context) {
 	_, invDB := tracer("inventory-service").Start(ctx6, "UPDATE inventory SET quantity = quantity - $1",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "postgresql"),
-			attribute.String("db.operation", "UPDATE"),
-			attribute.String("db.name", "inventory_db"),
+			attribute.String("db.system.name", "postgresql"),
+			attribute.String("db.operation.name", "UPDATE"),
+			attribute.String("db.namespace", "inventory_db"),
 		),
 	)
 	sleep(8, 25)
@@ -1453,9 +1488,9 @@ func fullCheckoutFlow(ctx context.Context) {
 	_, cacheSet := tracer("cache-service").Start(ctx, "Redis SET order:status",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "redis"),
-			attribute.String("db.operation", "SET"),
-			attribute.String("db.redis.key", "order:"+orderID),
+			attribute.String("db.system.name", "redis"),
+			attribute.String("db.operation.name", "SET"),
+			attribute.String("tracegen.redis.key", "order:"+orderID),
 		),
 	)
 	sleep(1, 3)
@@ -1466,7 +1501,7 @@ func fullCheckoutFlow(ctx context.Context) {
 		trace.WithSpanKind(trace.SpanKindProducer),
 		trace.WithAttributes(
 			attribute.String("messaging.system", "kafka"),
-			attribute.String("messaging.destination", "analytics.events"),
+			attribute.String("messaging.destination.name", "analytics.events"),
 			attribute.String("analytics.event_type", "checkout.complete"),
 			attribute.String("order.id", orderID),
 		),
@@ -1480,8 +1515,9 @@ func fullCheckoutFlow(ctx context.Context) {
 			trace.WithSpanKind(trace.SpanKindConsumer),
 			trace.WithAttributes(
 				attribute.String("messaging.system", "kafka"),
-				attribute.String("messaging.operation", "receive"),
-				attribute.String("messaging.destination", "analytics.events"),
+				attribute.String("messaging.operation.name", "receive"),
+				attribute.String("messaging.operation.type", "process"),
+				attribute.String("messaging.destination.name", "analytics.events"),
 				attribute.String("analytics.event_type", "checkout.complete"),
 				attribute.String("order.id", orderID),
 			),
@@ -1491,12 +1527,13 @@ func fullCheckoutFlow(ctx context.Context) {
 	}
 
 	// Queue notification
-	_, publish := tracer("order-service").Start(ctx, "rabbitmq publish orders.created",
+	_, publish := tracer("order-service").Start(ctx, "publish orders.created",
 		trace.WithSpanKind(trace.SpanKindProducer),
 		trace.WithAttributes(
 			attribute.String("messaging.system", "rabbitmq"),
-			attribute.String("messaging.operation", "publish"),
-			attribute.String("messaging.destination", "orders.created"),
+			attribute.String("messaging.operation.name", "publish"),
+			attribute.String("messaging.operation.type", "send"),
+			attribute.String("messaging.destination.name", "orders.created"),
 		),
 	)
 	sleep(2, 5)
@@ -1512,9 +1549,10 @@ func fullCheckoutFlow(ctx context.Context) {
 		trace.WithSpanKind(trace.SpanKindConsumer),
 		trace.WithAttributes(
 			attribute.String("messaging.system", "rabbitmq"),
-			attribute.String("messaging.operation", "receive"),
+			attribute.String("messaging.operation.name", "receive"),
+			attribute.String("messaging.operation.type", "process"),
 			// Correlate with the orders.created producer above.
-			attribute.String("messaging.destination", "orders.created"),
+			attribute.String("messaging.destination.name", "orders.created"),
 			attribute.String("notification.type", "order_confirmation"),
 			attribute.String("order.id", orderID),
 		),
@@ -1524,9 +1562,11 @@ func fullCheckoutFlow(ctx context.Context) {
 	_, email := tracer("email-service").Start(ctx7, "SendEmail",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
-			attribute.String("http.url", "https://api.sendgrid.com/v3/mail/send"),
-			attribute.String("peer.service", "sendgrid"),
+			attribute.String("http.request.method", "POST"),
+			attribute.String("url.full", "https://api.sendgrid.com/v3/mail/send"),
+			attribute.String("server.address", "api.sendgrid.com"),
+			attribute.Int("server.port", 443),
+			attribute.String("service.peer.name", "sendgrid"),
 			attribute.String("email.template", "order_confirmation"),
 		),
 	)
@@ -1546,7 +1586,7 @@ func shippingUpdateFlow(ctx context.Context) {
 	ctx, webhook := tracer("shipping-service").Start(ctx, "POST /webhooks/carrier",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
+			attribute.String("http.request.method", "POST"),
 			attribute.String("http.route", "/webhooks/carrier"),
 			attribute.String("webhook.carrier", "ups"),
 			attribute.String("webhook.event", "tracking.update"),
@@ -1581,9 +1621,9 @@ func shippingUpdateFlow(ctx context.Context) {
 	_, dbUpdate := tracer("order-service").Start(ctx2, "UPDATE orders SET shipping_status = $1",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "postgresql"),
-			attribute.String("db.operation", "UPDATE"),
-			attribute.String("db.name", "orders_db"),
+			attribute.String("db.system.name", "postgresql"),
+			attribute.String("db.operation.name", "UPDATE"),
+			attribute.String("db.namespace", "orders_db"),
 		),
 	)
 	sleep(5, 15)
@@ -1594,20 +1634,21 @@ func shippingUpdateFlow(ctx context.Context) {
 	_, cacheDel := tracer("cache-service").Start(ctx, "Redis DEL order:status",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "redis"),
-			attribute.String("db.operation", "DEL"),
+			attribute.String("db.system.name", "redis"),
+			attribute.String("db.operation.name", "DEL"),
 		),
 	)
 	sleep(1, 3)
 	cacheDel.End()
 
 	// Publish notification event
-	_, publish := tracer("shipping-service").Start(ctx, "rabbitmq publish shipping.updated",
+	_, publish := tracer("shipping-service").Start(ctx, "publish shipping.updated",
 		trace.WithSpanKind(trace.SpanKindProducer),
 		trace.WithAttributes(
 			attribute.String("messaging.system", "rabbitmq"),
-			attribute.String("messaging.operation", "publish"),
-			attribute.String("messaging.destination", "shipping.updated"),
+			attribute.String("messaging.operation.name", "publish"),
+			attribute.String("messaging.operation.type", "send"),
+			attribute.String("messaging.destination.name", "shipping.updated"),
 		),
 	)
 	sleep(2, 5)
@@ -1624,9 +1665,10 @@ func shippingUpdateFlow(ctx context.Context) {
 		trace.WithSpanKind(trace.SpanKindConsumer),
 		trace.WithAttributes(
 			attribute.String("messaging.system", "rabbitmq"),
-			attribute.String("messaging.operation", "receive"),
+			attribute.String("messaging.operation.name", "receive"),
+			attribute.String("messaging.operation.type", "process"),
 			// Correlate with the shipping.updated producer above.
-			attribute.String("messaging.destination", "shipping.updated"),
+			attribute.String("messaging.destination.name", "shipping.updated"),
 			attribute.String("notification.type", "shipping_update"),
 		),
 	)
@@ -1635,8 +1677,8 @@ func shippingUpdateFlow(ctx context.Context) {
 	_, email := tracer("email-service").Start(ctx3, "SendEmail",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
-			attribute.String("peer.service", "sendgrid"),
+			attribute.String("http.request.method", "POST"),
+			attribute.String("service.peer.name", "sendgrid"),
 			attribute.String("email.template", "shipping_update"),
 		),
 	)
@@ -1649,7 +1691,7 @@ func shippingUpdateFlow(ctx context.Context) {
 		trace.WithSpanKind(trace.SpanKindProducer),
 		trace.WithAttributes(
 			attribute.String("messaging.system", "kafka"),
-			attribute.String("messaging.destination", "analytics.events"),
+			attribute.String("messaging.destination.name", "analytics.events"),
 			attribute.String("analytics.event_type", "shipping.status_changed"),
 		),
 	)
@@ -1662,8 +1704,9 @@ func shippingUpdateFlow(ctx context.Context) {
 			trace.WithSpanKind(trace.SpanKindConsumer),
 			trace.WithAttributes(
 				attribute.String("messaging.system", "kafka"),
-				attribute.String("messaging.operation", "receive"),
-				attribute.String("messaging.destination", "analytics.events"),
+				attribute.String("messaging.operation.name", "receive"),
+				attribute.String("messaging.operation.type", "process"),
+				attribute.String("messaging.destination.name", "analytics.events"),
 				attribute.String("analytics.event_type", "shipping.status_changed"),
 			),
 		)
@@ -1679,9 +1722,11 @@ func sagaCompensationFlow(ctx context.Context) {
 	ctx, ui := tracer("web-frontend").Start(ctx, "Checkout",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
-			attribute.String("http.url", "/api/v2/checkout"),
-			attribute.String("browser.page", "/checkout/confirm"),
+			attribute.String("http.request.method", "POST"),
+			attribute.String("url.full", "https://shop.example.com/api/v2/checkout"),
+			attribute.String("server.address", "shop.example.com"),
+			attribute.Int("server.port", 443),
+			attribute.String("tracegen.browser.page", "/checkout/confirm"),
 		),
 	)
 	defer ui.End()
@@ -1690,9 +1735,9 @@ func sagaCompensationFlow(ctx context.Context) {
 	ctx, gateway := tracer("api-gateway").Start(ctx, "POST /api/v2/checkout",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
+			attribute.String("http.request.method", "POST"),
 			attribute.String("http.route", "/api/v2/checkout"),
-			attribute.Int("http.status_code", 402),
+			attribute.Int("http.response.status_code", 402),
 		),
 	)
 	defer gateway.End()
@@ -1725,9 +1770,9 @@ func sagaCompensationFlow(ctx context.Context) {
 	_, dbInsert := tracer("order-service").Start(ctx2, "INSERT orders",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "postgresql"),
-			attribute.String("db.operation", "INSERT"),
-			attribute.String("db.name", "orders_db"),
+			attribute.String("db.system.name", "postgresql"),
+			attribute.String("db.operation.name", "INSERT"),
+			attribute.String("db.namespace", "orders_db"),
 		),
 	)
 	sleep(5, 15)
@@ -1774,9 +1819,9 @@ func sagaCompensationFlow(ctx context.Context) {
 		_, retry := tracer("payment-service").Start(ctx3, fmt.Sprintf("POST https://api.stripe.com/v1/charges (attempt %d/3)", attempt),
 			trace.WithSpanKind(trace.SpanKindClient),
 			trace.WithAttributes(
-				attribute.String("http.method", "POST"),
-				attribute.String("peer.service", "stripe-api"),
-				attribute.Int("http.status_code", 402),
+				attribute.String("http.request.method", "POST"),
+				attribute.String("service.peer.name", "stripe-api"),
+				attribute.Int("http.response.status_code", 402),
 				attribute.Int("retry.attempt", attempt),
 			),
 		)
@@ -1790,12 +1835,13 @@ func sagaCompensationFlow(ctx context.Context) {
 	}
 
 	// Publish compensation event
-	_, compensate := tracer("payment-service").Start(ctx3, "rabbitmq publish saga.compensate",
+	_, compensate := tracer("payment-service").Start(ctx3, "publish saga.compensate",
 		trace.WithSpanKind(trace.SpanKindProducer),
 		trace.WithAttributes(
 			attribute.String("messaging.system", "rabbitmq"),
-			attribute.String("messaging.operation", "publish"),
-			attribute.String("messaging.destination", "saga.compensate"),
+			attribute.String("messaging.operation.name", "publish"),
+			attribute.String("messaging.operation.type", "send"),
+			attribute.String("messaging.destination.name", "saga.compensate"),
 			attribute.String("saga.reason", "payment_failed"),
 			attribute.String("order.id", orderID),
 		),
@@ -1819,7 +1865,7 @@ func sagaCompensationFlow(ctx context.Context) {
 			trace.WithSpanKind(trace.SpanKindConsumer),
 			trace.WithAttributes(
 				attribute.String("messaging.system", "rabbitmq"),
-				attribute.String("messaging.destination", "saga.compensate"),
+				attribute.String("messaging.destination.name", "saga.compensate"),
 				attribute.String("saga.action", "cancel_order"),
 				attribute.String("order.id", orderID),
 			),
@@ -1828,9 +1874,9 @@ func sagaCompensationFlow(ctx context.Context) {
 		_, dbCancel := tracer("order-service").Start(ctx4, "UPDATE orders SET status = 'cancelled'",
 			trace.WithSpanKind(trace.SpanKindClient),
 			trace.WithAttributes(
-				attribute.String("db.system", "postgresql"),
-				attribute.String("db.operation", "UPDATE"),
-				attribute.String("db.name", "orders_db"),
+				attribute.String("db.system.name", "postgresql"),
+				attribute.String("db.operation.name", "UPDATE"),
+				attribute.String("db.namespace", "orders_db"),
 			),
 		)
 		sleep(5, 15)
@@ -1845,7 +1891,7 @@ func sagaCompensationFlow(ctx context.Context) {
 			trace.WithSpanKind(trace.SpanKindConsumer),
 			trace.WithAttributes(
 				attribute.String("messaging.system", "rabbitmq"),
-				attribute.String("messaging.destination", "saga.compensate"),
+				attribute.String("messaging.destination.name", "saga.compensate"),
 				attribute.String("saga.action", "release_stock"),
 				attribute.String("order.id", orderID),
 			),
@@ -1854,9 +1900,9 @@ func sagaCompensationFlow(ctx context.Context) {
 		_, dbRelease := tracer("inventory-service").Start(ctx4, "UPDATE inventory SET quantity = quantity + $1",
 			trace.WithSpanKind(trace.SpanKindClient),
 			trace.WithAttributes(
-				attribute.String("db.system", "postgresql"),
-				attribute.String("db.operation", "UPDATE"),
-				attribute.String("db.name", "inventory_db"),
+				attribute.String("db.system.name", "postgresql"),
+				attribute.String("db.operation.name", "UPDATE"),
+				attribute.String("db.namespace", "inventory_db"),
 			),
 		)
 		sleep(5, 15)
@@ -1871,7 +1917,7 @@ func sagaCompensationFlow(ctx context.Context) {
 			trace.WithSpanKind(trace.SpanKindConsumer),
 			trace.WithAttributes(
 				attribute.String("messaging.system", "rabbitmq"),
-				attribute.String("messaging.destination", "saga.compensate"),
+				attribute.String("messaging.destination.name", "saga.compensate"),
 				attribute.String("saga.action", "void_shipping"),
 				attribute.String("order.id", orderID),
 			),
@@ -1887,7 +1933,7 @@ func sagaCompensationFlow(ctx context.Context) {
 			trace.WithSpanKind(trace.SpanKindConsumer),
 			trace.WithAttributes(
 				attribute.String("messaging.system", "rabbitmq"),
-				attribute.String("messaging.destination", "saga.compensate"),
+				attribute.String("messaging.destination.name", "saga.compensate"),
 				attribute.String("notification.type", "order_canceled"),
 				attribute.String("order.id", orderID),
 			),
@@ -1896,7 +1942,7 @@ func sagaCompensationFlow(ctx context.Context) {
 		_, email := tracer("email-service").Start(ctx4, "SendEmail",
 			trace.WithSpanKind(trace.SpanKindClient),
 			trace.WithAttributes(
-				attribute.String("peer.service", "sendgrid"),
+				attribute.String("service.peer.name", "sendgrid"),
 				attribute.String("email.template", "order_canceled"),
 			),
 		)
@@ -1915,7 +1961,7 @@ func sagaCompensationFlow(ctx context.Context) {
 		trace.WithSpanKind(trace.SpanKindProducer),
 		trace.WithAttributes(
 			attribute.String("messaging.system", "kafka"),
-			attribute.String("messaging.destination", "analytics.events"),
+			attribute.String("messaging.destination.name", "analytics.events"),
 			attribute.String("analytics.event_type", "order.cancelled"),
 			attribute.String("order.id", orderID),
 		),
@@ -1929,8 +1975,9 @@ func sagaCompensationFlow(ctx context.Context) {
 			trace.WithSpanKind(trace.SpanKindConsumer),
 			trace.WithAttributes(
 				attribute.String("messaging.system", "kafka"),
-				attribute.String("messaging.operation", "receive"),
-				attribute.String("messaging.destination", "analytics.events"),
+				attribute.String("messaging.operation.name", "receive"),
+				attribute.String("messaging.operation.type", "process"),
+				attribute.String("messaging.destination.name", "analytics.events"),
 				attribute.String("analytics.event_type", "order.cancelled"),
 				attribute.String("order.id", orderID),
 			),
@@ -1947,9 +1994,11 @@ func timeoutCascadeFlow(ctx context.Context) {
 	ctx, ui := tracer("web-frontend").Start(ctx, "SearchProducts",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("http.method", "GET"),
-			attribute.String("http.url", "/api/v2/search"),
-			attribute.String("browser.page", "/search"),
+			attribute.String("http.request.method", "GET"),
+			attribute.String("url.full", "https://shop.example.com/api/v2/search"),
+			attribute.String("server.address", "shop.example.com"),
+			attribute.Int("server.port", 443),
+			attribute.String("tracegen.browser.page", "/search"),
 			attribute.String("search.query", randomSearchTerm()),
 		),
 	)
@@ -1960,9 +2009,9 @@ func timeoutCascadeFlow(ctx context.Context) {
 	_, gw1 := tracer("api-gateway").Start(ctx, "GET /api/v2/search (attempt 1/2)",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String("http.method", "GET"),
+			attribute.String("http.request.method", "GET"),
 			attribute.String("http.route", "/api/v2/search"),
-			attribute.Int("http.status_code", 504),
+			attribute.Int("http.response.status_code", 504),
 			attribute.Int("retry.attempt", 1),
 		),
 	)
@@ -1972,8 +2021,8 @@ func timeoutCascadeFlow(ctx context.Context) {
 	_, slowSearch := tracer("search-service").Start(ctx, "Elasticsearch Query (slow)",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String("db.system", "elasticsearch"),
-			attribute.String("db.operation", "search"),
+			attribute.String("db.system.name", "elasticsearch"),
+			attribute.String("db.operation.name", "search"),
 			attribute.Bool("timeout.exceeded", true),
 		),
 	)
@@ -1995,9 +2044,9 @@ func timeoutCascadeFlow(ctx context.Context) {
 	_, gw2 := tracer("api-gateway").Start(ctx, "GET /api/v2/search (attempt 2/2)",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String("http.method", "GET"),
+			attribute.String("http.request.method", "GET"),
 			attribute.String("http.route", "/api/v2/search"),
-			attribute.Int("http.status_code", 200),
+			attribute.Int("http.response.status_code", 200),
 			attribute.Int("retry.attempt", 2),
 			attribute.Bool("circuit_breaker.open", true),
 			attribute.String("circuit_breaker.fallback", "stale_cache"),
@@ -2020,8 +2069,8 @@ func timeoutCascadeFlow(ctx context.Context) {
 	_, cacheHit := tracer("cache-service").Start(ctx, "Redis GET search-cache (stale)",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "redis"),
-			attribute.String("db.operation", "GET"),
+			attribute.String("db.system.name", "redis"),
+			attribute.String("db.operation.name", "GET"),
 			attribute.Bool("cache.hit", true),
 			attribute.Bool("cache.stale", true),
 			attribute.Int("cache.age_seconds", 300+rand.Intn(600)),
@@ -2036,7 +2085,7 @@ func timeoutCascadeFlow(ctx context.Context) {
 		trace.WithSpanKind(trace.SpanKindProducer),
 		trace.WithAttributes(
 			attribute.String("messaging.system", "kafka"),
-			attribute.String("messaging.destination", "analytics.events"),
+			attribute.String("messaging.destination.name", "analytics.events"),
 			attribute.String("analytics.event_type", "search.degraded"),
 			attribute.String("degradation.reason", "elasticsearch_timeout"),
 		),
@@ -2050,8 +2099,9 @@ func timeoutCascadeFlow(ctx context.Context) {
 			trace.WithSpanKind(trace.SpanKindConsumer),
 			trace.WithAttributes(
 				attribute.String("messaging.system", "kafka"),
-				attribute.String("messaging.operation", "receive"),
-				attribute.String("messaging.destination", "analytics.events"),
+				attribute.String("messaging.operation.name", "receive"),
+				attribute.String("messaging.operation.type", "process"),
+				attribute.String("messaging.destination.name", "analytics.events"),
 				attribute.String("analytics.event_type", "search.degraded"),
 			),
 		)

--- a/cmd/snowglobe/scenarios_ai.go
+++ b/cmd/snowglobe/scenarios_ai.go
@@ -21,9 +21,11 @@ func ragSearchFlow(ctx context.Context) {
 	ctx, ui := tracer("web-frontend").Start(ctx, "SearchProducts",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("http.method", "GET"),
-			attribute.String("http.url", "/api/v2/search/ai"),
-			attribute.String("browser.page", "/search"),
+			attribute.String("http.request.method", "GET"),
+			attribute.String("url.full", "https://shop.example.com/api/v2/search/ai"),
+			attribute.String("server.address", "shop.example.com"),
+			attribute.Int("server.port", 443),
+			attribute.String("tracegen.browser.page", "/search"),
 			attribute.String("search.query", query),
 		),
 	)
@@ -33,9 +35,9 @@ func ragSearchFlow(ctx context.Context) {
 	ctx, gateway := tracer("api-gateway").Start(ctx, "GET /api/v2/search/ai",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String("http.method", "GET"),
+			attribute.String("http.request.method", "GET"),
 			attribute.String("http.route", "/api/v2/search/ai"),
-			attribute.Int("http.status_code", 200),
+			attribute.Int("http.response.status_code", 200),
 			attribute.String("search.query", query),
 		),
 	)
@@ -83,8 +85,8 @@ func ragSearchFlow(ctx context.Context) {
 		_, esFallback := tracer("search-service").Start(ctx, "Elasticsearch Query (fallback)",
 			trace.WithSpanKind(trace.SpanKindServer),
 			trace.WithAttributes(
-				attribute.String("db.system", "elasticsearch"),
-				attribute.String("db.operation", "search"),
+				attribute.String("db.system.name", "elasticsearch"),
+				attribute.String("db.operation.name", "search"),
 				attribute.Bool("search.fallback", true),
 				attribute.String("search.fallback_reason", "llm_rate_limit"),
 				attribute.Int("search.results_count", rand.Intn(30)),
@@ -99,13 +101,13 @@ func ragSearchFlow(ctx context.Context) {
 
 	// Vector similarity search
 	resultsReturned := 15 + rand.Intn(6)
-	_, vecSearch := tracer("vector-db-service").Start(ctx, "retrieve product-embeddings",
+	_, vecSearch := tracer("vector-db-service").Start(ctx, "retrieval product-embeddings",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("gen_ai.operation.name", "retrieve"),
+			attribute.String("gen_ai.operation.name", "retrieval"),
 			attribute.String("gen_ai.data_source.id", "product-embeddings"),
-			attribute.String("db.system", "qdrant"),
-			attribute.String("db.operation", "search"),
+			attribute.String("db.system.name", "qdrant"),
+			attribute.String("db.operation.name", "search"),
 			attribute.Int("vector_db.top_k", 20),
 			attribute.Int("vector_db.results_returned", resultsReturned),
 			attribute.String("vector_db.similarity_metric", "cosine"),
@@ -140,9 +142,9 @@ func ragSearchFlow(ctx context.Context) {
 	_, cacheSet := tracer("cache-service").Start(ctx, "Redis SET search-cache",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "redis"),
-			attribute.String("db.operation", "SET"),
-			attribute.Int("db.redis.ttl_seconds", 300),
+			attribute.String("db.system.name", "redis"),
+			attribute.String("db.operation.name", "SET"),
+			attribute.Int("tracegen.redis.ttl_seconds", 300),
 		),
 	)
 	sleep(1, 3)
@@ -153,7 +155,7 @@ func ragSearchFlow(ctx context.Context) {
 		trace.WithSpanKind(trace.SpanKindProducer),
 		trace.WithAttributes(
 			attribute.String("messaging.system", "kafka"),
-			attribute.String("messaging.destination", "analytics.events"),
+			attribute.String("messaging.destination.name", "analytics.events"),
 			attribute.String("analytics.event_type", "semantic_search.complete"),
 			attribute.Int("search.results_count", resultsReturned),
 		),
@@ -167,8 +169,9 @@ func ragSearchFlow(ctx context.Context) {
 			trace.WithSpanKind(trace.SpanKindConsumer),
 			trace.WithAttributes(
 				attribute.String("messaging.system", "kafka"),
-				attribute.String("messaging.operation", "receive"),
-				attribute.String("messaging.destination", "analytics.events"),
+				attribute.String("messaging.operation.name", "receive"),
+				attribute.String("messaging.operation.type", "process"),
+				attribute.String("messaging.destination.name", "analytics.events"),
 				attribute.String("analytics.event_type", "semantic_search.complete"),
 			),
 		)
@@ -188,9 +191,11 @@ func aiChatbotFlow(ctx context.Context) {
 	ctx, ui := tracer("web-frontend").Start(ctx, "SendChatMessage",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
-			attribute.String("http.url", "/api/v2/chat"),
-			attribute.String("browser.page", "/support/chat"),
+			attribute.String("http.request.method", "POST"),
+			attribute.String("url.full", "https://shop.example.com/api/v2/chat"),
+			attribute.String("server.address", "shop.example.com"),
+			attribute.Int("server.port", 443),
+			attribute.String("tracegen.browser.page", "/support/chat"),
 			attribute.String("user.session_id", userID),
 		),
 	)
@@ -200,9 +205,9 @@ func aiChatbotFlow(ctx context.Context) {
 	ctx, gateway := tracer("api-gateway").Start(ctx, "POST /api/v2/chat",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
+			attribute.String("http.request.method", "POST"),
 			attribute.String("http.route", "/api/v2/chat"),
-			attribute.Int("http.status_code", 200),
+			attribute.Int("http.response.status_code", 200),
 		),
 	)
 	defer gateway.End()
@@ -279,8 +284,8 @@ func aiChatbotFlow(ctx context.Context) {
 		_, search := tracer("search-service").Start(toolCtx, "Elasticsearch Query",
 			trace.WithSpanKind(trace.SpanKindServer),
 			trace.WithAttributes(
-				attribute.String("db.system", "elasticsearch"),
-				attribute.String("db.operation", "search"),
+				attribute.String("db.system.name", "elasticsearch"),
+				attribute.String("db.operation.name", "search"),
 				attribute.Int("search.results_count", rand.Intn(20)),
 			),
 		)
@@ -332,10 +337,10 @@ func aiChatbotFlow(ctx context.Context) {
 	_, cacheSet := tracer("cache-service").Start(ctx, "Redis SET conversation:session",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "redis"),
-			attribute.String("db.operation", "SET"),
-			attribute.String("db.redis.key", "conversation:"+sessionID),
-			attribute.Int("db.redis.ttl_seconds", 1800),
+			attribute.String("db.system.name", "redis"),
+			attribute.String("db.operation.name", "SET"),
+			attribute.String("tracegen.redis.key", "conversation:"+sessionID),
+			attribute.Int("tracegen.redis.ttl_seconds", 1800),
 		),
 	)
 	sleep(1, 3)
@@ -349,9 +354,11 @@ func contentModerationFlow(ctx context.Context) {
 	ctx, ui := tracer("web-frontend").Start(ctx, "SubmitReview",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
-			attribute.String("http.url", "/api/v2/reviews"),
-			attribute.String("browser.page", "/product/review"),
+			attribute.String("http.request.method", "POST"),
+			attribute.String("url.full", "https://shop.example.com/api/v2/reviews"),
+			attribute.String("server.address", "shop.example.com"),
+			attribute.Int("server.port", 443),
+			attribute.String("tracegen.browser.page", "/product/review"),
 		),
 	)
 	defer ui.End()
@@ -360,7 +367,7 @@ func contentModerationFlow(ctx context.Context) {
 	ctx, gateway := tracer("api-gateway").Start(ctx, "POST /api/v2/reviews",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
+			attribute.String("http.request.method", "POST"),
 			attribute.String("http.route", "/api/v2/reviews"),
 		),
 	)
@@ -462,7 +469,7 @@ func contentModerationFlow(ctx context.Context) {
 		sleep(10, 30)
 		publish.End()
 
-		gateway.SetAttributes(attribute.Int("http.status_code", 201))
+		gateway.SetAttributes(attribute.Int("http.response.status_code", 201))
 
 	case "flag":
 		emitLog(ctx, "content-moderation-service", logapi.SeverityWarn, "Content flagged for human review")
@@ -471,8 +478,9 @@ func contentModerationFlow(ctx context.Context) {
 			trace.WithSpanKind(trace.SpanKindProducer),
 			trace.WithAttributes(
 				attribute.String("messaging.system", "rabbitmq"),
-				attribute.String("messaging.operation", "publish"),
-				attribute.String("messaging.destination", "moderation.review_queue"),
+				attribute.String("messaging.operation.name", "publish"),
+				attribute.String("messaging.operation.type", "send"),
+				attribute.String("messaging.destination.name", "moderation.review_queue"),
 				attribute.String("review.status", "flagged"),
 			),
 		)
@@ -485,8 +493,9 @@ func contentModerationFlow(ctx context.Context) {
 				trace.WithSpanKind(trace.SpanKindConsumer),
 				trace.WithAttributes(
 					attribute.String("messaging.system", "rabbitmq"),
-					attribute.String("messaging.operation", "receive"),
-					attribute.String("messaging.destination", "moderation.review_queue"),
+					attribute.String("messaging.operation.name", "receive"),
+					attribute.String("messaging.operation.type", "process"),
+					attribute.String("messaging.destination.name", "moderation.review_queue"),
 					attribute.String("review.status", "pending_human_review"),
 				),
 			)
@@ -494,7 +503,7 @@ func contentModerationFlow(ctx context.Context) {
 			reviewer.End()
 		}
 
-		gateway.SetAttributes(attribute.Int("http.status_code", 202))
+		gateway.SetAttributes(attribute.Int("http.response.status_code", 202))
 
 	case "block":
 		// Content blocked
@@ -502,7 +511,7 @@ func contentModerationFlow(ctx context.Context) {
 		exc := randomException(moderationExceptions)
 		recordException(ctx, "content-moderation-service", moderation, exc.excType, exc.message, exc.stacktrace)
 
-		gateway.SetAttributes(attribute.Int("http.status_code", 422))
+		gateway.SetAttributes(attribute.Int("http.response.status_code", 422))
 		gateway.SetStatus(codes.Error, "content blocked by moderation")
 	}
 }
@@ -516,9 +525,11 @@ func multiStepAgentFlow(ctx context.Context) {
 	ctx, ui := tracer("web-frontend").Start(ctx, "SubmitAgentTask",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
-			attribute.String("http.url", "/api/v2/agent/task"),
-			attribute.String("browser.page", "/agent/task"),
+			attribute.String("http.request.method", "POST"),
+			attribute.String("url.full", "https://shop.example.com/api/v2/agent/task"),
+			attribute.String("server.address", "shop.example.com"),
+			attribute.Int("server.port", 443),
+			attribute.String("tracegen.browser.page", "/agent/task"),
 		),
 	)
 	defer ui.End()
@@ -527,9 +538,9 @@ func multiStepAgentFlow(ctx context.Context) {
 	ctx, gateway := tracer("api-gateway").Start(ctx, "POST /api/v2/agent/task",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
+			attribute.String("http.request.method", "POST"),
 			attribute.String("http.route", "/api/v2/agent/task"),
-			attribute.Int("http.status_code", 200),
+			attribute.Int("http.response.status_code", 200),
 		),
 	)
 	defer gateway.End()
@@ -606,8 +617,8 @@ func multiStepAgentFlow(ctx context.Context) {
 			_, search := tracer("search-service").Start(toolCtx, "Elasticsearch Query",
 				trace.WithSpanKind(trace.SpanKindServer),
 				trace.WithAttributes(
-					attribute.String("db.system", "elasticsearch"),
-					attribute.String("db.operation", "search"),
+					attribute.String("db.system.name", "elasticsearch"),
+					attribute.String("db.operation.name", "search"),
 					attribute.Int("search.results_count", rand.Intn(30)),
 				),
 			)
@@ -688,9 +699,9 @@ func multiStepAgentFlow(ctx context.Context) {
 	_, cacheSet := tracer("cache-service").Start(ctx, "Redis SET agent:result",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "redis"),
-			attribute.String("db.operation", "SET"),
-			attribute.Int("db.redis.ttl_seconds", 600),
+			attribute.String("db.system.name", "redis"),
+			attribute.String("db.operation.name", "SET"),
+			attribute.Int("tracegen.redis.ttl_seconds", 600),
 		),
 	)
 	sleep(1, 3)
@@ -701,7 +712,7 @@ func multiStepAgentFlow(ctx context.Context) {
 		trace.WithSpanKind(trace.SpanKindProducer),
 		trace.WithAttributes(
 			attribute.String("messaging.system", "kafka"),
-			attribute.String("messaging.destination", "analytics.events"),
+			attribute.String("messaging.destination.name", "analytics.events"),
 			attribute.String("analytics.event_type", "agent.task_complete"),
 			attribute.Int("agent.total_iterations", iterations),
 			attribute.Int("agent.total_input_tokens", totalInputTokens),
@@ -717,8 +728,9 @@ func multiStepAgentFlow(ctx context.Context) {
 			trace.WithSpanKind(trace.SpanKindConsumer),
 			trace.WithAttributes(
 				attribute.String("messaging.system", "kafka"),
-				attribute.String("messaging.operation", "receive"),
-				attribute.String("messaging.destination", "analytics.events"),
+				attribute.String("messaging.operation.name", "receive"),
+				attribute.String("messaging.operation.type", "process"),
+				attribute.String("messaging.destination.name", "analytics.events"),
 				attribute.String("analytics.event_type", "agent.task_complete"),
 			),
 		)
@@ -737,9 +749,11 @@ func returnRefundFlow(ctx context.Context) {
 	ctx, ui := tracer("web-frontend").Start(ctx, "RequestReturn",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
-			attribute.String("http.url", "/api/v2/returns"),
-			attribute.String("browser.page", "/orders/return"),
+			attribute.String("http.request.method", "POST"),
+			attribute.String("url.full", "https://shop.example.com/api/v2/returns"),
+			attribute.String("server.address", "shop.example.com"),
+			attribute.Int("server.port", 443),
+			attribute.String("tracegen.browser.page", "/orders/return"),
 			attribute.String("order.id", orderID),
 		),
 	)
@@ -749,9 +763,9 @@ func returnRefundFlow(ctx context.Context) {
 	ctx, gateway := tracer("api-gateway").Start(ctx, "POST /api/v2/returns",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
+			attribute.String("http.request.method", "POST"),
 			attribute.String("http.route", "/api/v2/returns"),
-			attribute.Int("http.status_code", 200),
+			attribute.Int("http.response.status_code", 200),
 		),
 	)
 	defer gateway.End()
@@ -782,9 +796,9 @@ func returnRefundFlow(ctx context.Context) {
 	_, dbLookup := tracer("order-service").Start(ctx2, "SELECT orders WHERE id = $1",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "postgresql"),
-			attribute.String("db.operation", "SELECT"),
-			attribute.String("db.name", "orders_db"),
+			attribute.String("db.system.name", "postgresql"),
+			attribute.String("db.operation.name", "SELECT"),
+			attribute.String("db.namespace", "orders_db"),
 		),
 	)
 	sleep(5, 15)
@@ -794,9 +808,9 @@ func returnRefundFlow(ctx context.Context) {
 	_, dbUpdate := tracer("order-service").Start(ctx2, "UPDATE orders SET status = 'return_initiated'",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("db.system", "postgresql"),
-			attribute.String("db.operation", "UPDATE"),
-			attribute.String("db.name", "orders_db"),
+			attribute.String("db.system.name", "postgresql"),
+			attribute.String("db.operation.name", "UPDATE"),
+			attribute.String("db.namespace", "orders_db"),
 		),
 	)
 	sleep(5, 15)
@@ -822,10 +836,12 @@ func returnRefundFlow(ctx context.Context) {
 		_, stripeRefund := tracer("payment-service").Start(ctx3, "POST https://api.stripe.com/v1/refunds",
 			trace.WithSpanKind(trace.SpanKindClient),
 			trace.WithAttributes(
-				attribute.String("http.method", "POST"),
-				attribute.String("http.url", "https://api.stripe.com/v1/refunds"),
-				attribute.String("peer.service", "stripe-api"),
-				attribute.Int("http.status_code", 200),
+				attribute.String("http.request.method", "POST"),
+				attribute.String("url.full", "https://api.stripe.com/v1/refunds"),
+				attribute.String("server.address", "api.stripe.com"),
+				attribute.Int("server.port", 443),
+				attribute.String("service.peer.name", "stripe-api"),
+				attribute.Int("http.response.status_code", 200),
 			),
 		)
 		sleep(80, 250)
@@ -848,9 +864,9 @@ func returnRefundFlow(ctx context.Context) {
 		_, dbRestock := tracer("inventory-service").Start(ctx3, "UPDATE inventory SET quantity = quantity + $1",
 			trace.WithSpanKind(trace.SpanKindClient),
 			trace.WithAttributes(
-				attribute.String("db.system", "postgresql"),
-				attribute.String("db.operation", "UPDATE"),
-				attribute.String("db.name", "inventory_db"),
+				attribute.String("db.system.name", "postgresql"),
+				attribute.String("db.operation.name", "UPDATE"),
+				attribute.String("db.namespace", "inventory_db"),
 			),
 		)
 		sleep(5, 15)
@@ -860,8 +876,8 @@ func returnRefundFlow(ctx context.Context) {
 		_, cacheDel := tracer("cache-service").Start(ctx3, "Redis DEL inventory-cache",
 			trace.WithSpanKind(trace.SpanKindClient),
 			trace.WithAttributes(
-				attribute.String("db.system", "redis"),
-				attribute.String("db.operation", "DEL"),
+				attribute.String("db.system.name", "redis"),
+				attribute.String("db.operation.name", "DEL"),
 			),
 		)
 		sleep(1, 3)
@@ -887,8 +903,8 @@ func returnRefundFlow(ctx context.Context) {
 	_, email := tracer("email-service").Start(ctx3, "SendEmail",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String("http.method", "POST"),
-			attribute.String("peer.service", "sendgrid"),
+			attribute.String("http.request.method", "POST"),
+			attribute.String("service.peer.name", "sendgrid"),
 			attribute.String("email.template", "refund_confirmation"),
 		),
 	)
@@ -901,7 +917,7 @@ func returnRefundFlow(ctx context.Context) {
 		trace.WithSpanKind(trace.SpanKindProducer),
 		trace.WithAttributes(
 			attribute.String("messaging.system", "kafka"),
-			attribute.String("messaging.destination", "analytics.events"),
+			attribute.String("messaging.destination.name", "analytics.events"),
 			attribute.String("analytics.event_type", "order.refunded"),
 			attribute.String("order.id", orderID),
 			attribute.Float64("refund.amount", refundAmount),
@@ -916,8 +932,9 @@ func returnRefundFlow(ctx context.Context) {
 			trace.WithSpanKind(trace.SpanKindConsumer),
 			trace.WithAttributes(
 				attribute.String("messaging.system", "kafka"),
-				attribute.String("messaging.operation", "receive"),
-				attribute.String("messaging.destination", "analytics.events"),
+				attribute.String("messaging.operation.name", "receive"),
+				attribute.String("messaging.operation.type", "process"),
+				attribute.String("messaging.destination.name", "analytics.events"),
 				attribute.String("analytics.event_type", "order.refunded"),
 				attribute.String("order.id", orderID),
 			),

--- a/docs/metrics-design.md
+++ b/docs/metrics-design.md
@@ -16,7 +16,7 @@ spans and decremented by consumer spans. That last one means `-no-consumers` pro
 unbounded backlog rather than a simulated one, and it costs less code than a random walk would have.
 
 **GenAI metrics need no scenario changes either.** The AI scenarios already stamp
-`gen_ai.operation.name`, `gen_ai.system`, `gen_ai.request.model` and token counts on their spans, so
+`gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.request.model` and token counts on their spans, so
 the same span processor derives the metrics. The net result is that all four layers are implemented
 with **zero edits to the ~3,000 lines of scenario code**.
 
@@ -94,7 +94,7 @@ execution.
 | Metric | Instrument | Unit | Notes |
 |---|---|---|---|
 | `system.cpu.utilization` | Gauge | `1` | Per pod, correlated with that pod's scenario activity |
-| `system.memory.usage` | Gauge | `By` | |
+| `system.memory.usage` | UpDownCounter | `By` | `system.memory.state`. The registry defines this as an updowncounter, not a gauge |
 | `http.server.active_requests` | UpDownCounter | `{request}` | Semconv; rises and falls with in-flight scenarios |
 | `db.client.connection.count` | UpDownCounter | `{connection}` | Semconv, with `db.client.connection.state` = `used`/`idle` |
 | `tracegen.messaging.queue.depth` | Gauge | `{message}` | Per `messaging.destination.name` |
@@ -120,7 +120,7 @@ on the trace side.
 
 | Metric | Instrument | Unit | Attributes |
 |---|---|---|---|
-| `gen_ai.client.token.usage` | Histogram | `{token}` | `gen_ai.operation.name`, `gen_ai.system`, `gen_ai.request.model`, `gen_ai.token.type` (`input`/`output`) |
+| `gen_ai.client.token.usage` | Histogram | `{token}` | `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.request.model`, `gen_ai.token.type` (`input`/`output`) |
 | `gen_ai.client.operation.duration` | Histogram | `s` | Same, plus `error.type` where applicable |
 
 Token counts already exist as `gen_ai.usage.input_tokens` / `output_tokens` span attributes, so this is


### PR DESCRIPTION
Closes the Snowglobe half of the OpenTelemetry semantic-convention conformance failure. Shoebox's half closed 2026-08-23.

The claim under verification was **"Snowglobe and Shoebox emit standard OpenTelemetry telemetry. Nothing is invented."** It was FAIL. Evidence is the C3 verification matrix from bus thread #2165, preserved in IF.Knowledge at `.context/current/discoveries/snowglobe-shoebox-semconv-conformance.md`, with every row cited to the semconv release that deprecated or introduced the name.

Every count in that matrix was independently re-verified against this tree before any edit. All fourteen matched exactly, 331 occurrences.

## Ordering

This could not ship earlier. The DeepCube client read only the deprecated `messaging.destination`, so the phantom grid worked *because* Snowglobe emitted the old name, and renaming first would have taken the live grid down looking like Snowglobe broke. `IF.APM.App.Unity.HDRP` PR 3654 fixed the reader on 2026-08-24.

Clients older than 3654 still read only the old name and their grids will go dark on this change. The founder accepted that explicitly on 2026-08-25 rather than gating on client rollout.

## Seam 1: deprecated names

`http.method`→`http.request.method` (58), `db.system`→`db.system.name` (50), `db.operation`→`db.operation.name` (49), `messaging.destination`→`messaging.destination.name` (39), `http.status_code`→`http.response.status_code` (33), `http.url`→`url.full` (23), `peer.service`→`service.peer.name` (17), `db.name`→`db.namespace` (17), `gen_ai.system`→`gen_ai.provider.name` (6), `net.peer.ip`→`network.peer.address` (3), `db.statement`→`db.query.text` (3), `http.user_agent`→`user_agent.original` (1).

`messaging.operation` was **not** a rename. It split in v1.26.0, so all 25 call sites now carry `messaging.operation.name` (free-text verb) and `messaging.operation.type` (registered enum). The enum values matter: producers are `send`, not `publish`, and consumers keeping `SpanKindConsumer` are `process`, not `receive` — only `process` maps to CONSUMER in the spec's operation-type/span-kind table. `trackMessaging` now classifies on `.type`, which is what a conformant backend keys on.

## Seam 2: fabricated names inside reserved namespaces

| was | now | why |
|---|---|---|
| `messaging.batch_size` | `messaging.batch.message_count` | registered name exists |
| `db.rows_affected` | `db.response.returned_rows` | both sites verified `SELECT`, so "returned rows" is honest |
| `db.docs_count` | `tracegen.db.docs_count` | `bulk_index` write, no registered equivalent, so out of `db.*` |
| `db.redis.*` | `tracegen.redis.*` | only `db.redis.database_index` was ever registered, and it is deprecated |
| `browser.page` | `tracegen.browser.page` | `browser.*` **is** reserved; `browser.page` is not a member at any version |

Also invalid enum values: `gen_ai.operation.name` `retrieve`→`retrieval` and `embedding`→`embeddings`, with the span names that follow them. Producer span names dropped the spurious system token: `rabbitmq publish X` → `publish X`.

## Seam 3: wire format

`system.memory.usage` was an `ObservableGauge`. The registry defines it as an **updowncounter**. That is a different point kind on the wire, not a label. Now `Int64ObservableUpDownCounter`, carrying the Recommended `system.memory.state` it never had.

## Required attributes that were simply absent

`url.scheme` on `http.server.active_requests`; `db.client.connection.pool.name` on `db.client.connection.count`; `cpu.mode` on `system.cpu.utilization`; `server.address` + `server.port` on all 23 HTTP client spans.

## One thing the matrix missed, found by making its change

The matrix recorded `http.url` as holding "a Full URL string". It does not. **17 of 23 sites held a relative path**, and `url.full` is defined as the absolute URL, so the rename alone would have put a path in a full-URL field and called it conformant. Those are now absolute, which is also what makes the co-required `server.address` honest rather than invented.

## Verified by running it

Built the binary, stood up a minimal OTLP gRPC sink, and read the wire across a traditional run and an `-ai-only -complexity heavy` run: 90 distinct span-attribute keys, 8 metrics. **Zero** deprecated names, **zero** fabricated members of a reserved namespace, `system.memory.usage` arriving as a non-monotonic Sum, and `gen_ai.provider.name` in both GenAI metrics with no `gen_ai.system` anywhere. `go build`, `go vet`, `go test` clean.

## Deliberately not done

**Consumer span names** (`ProcessPayment`, `ReserveStock`, `SendOrderConfirmation`). The matrix offers two ways to fix the operation/business-name conflation and both change what the demo grids visibly look like. Product call, not a conformance one.

**The `tracegen.*` → `snowglobe.*` prefix.** Kept `tracegen.*` so this adds no second custom namespace, but `tracegen.messaging.queue.depth` is a live metric and renaming it breaks anything keyed on it. Separate change, separate blast radius.

## Deploying this

All 15 Argo apps run automated sync with prune against main, and `charts/snowglobe/values.yaml` pins `0.9.1`, so a release plus a tag bump reaches the demo grids with no gate. **No tag is cut in this PR** — that is a deliberate separate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
