### PR TITLE
Correct the image size, and stop asking for a tracegen invocation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,10 +9,10 @@ labels: bug
 A clear description of the bug.
 
 **Command**
-The exact `tracegen` invocation (flags, env vars):
+The exact `snowglobe` invocation (flags, env vars):
 
 ```
-tracegen ...
+snowglobe ...
 ```
 
 **Expected vs. actual**

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,7 +36,7 @@ linters:
       - path: _test\.go
         linters:
           - gosec
-      # G404: tracegen emits SYNTHETIC telemetry; math/rand (weak PRNG) is the
+      # G404: Snowglobe emits SYNTHETIC telemetry; math/rand (weak PRNG) is the
       # whole point of the tool and is not security-sensitive.
       - linters: [gosec]
         text: "G404"

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -2,7 +2,7 @@
      (the description API rejects PATs). When you change this, re-paste it on Docker Hub. -->
 # Snowglobe
 
-**One container that emits realistic, topology-rich OpenTelemetry traces, logs and metrics, including AI agentic spans.** No microservices to deploy, no Docker Compose with 15 containers. A single 5.7 MB image simulates a full e-commerce platform: up to 28 services, dozens of pods that scale with the topology, 40 scenario flows, and 10 injectable failure modes, with full OTel GenAI semantic conventions for LLM/agent observability.
+**One container that emits realistic, topology-rich OpenTelemetry traces, logs and metrics, including AI agentic spans.** No microservices to deploy, no Docker Compose with 15 containers. A single 6.4 MB image simulates a full e-commerce platform: up to 28 services, dozens of pods that scale with the topology, 40 scenario flows, and 10 injectable failure modes, with full OTel GenAI semantic conventions for LLM/agent observability.
 
 Built for testing observability platforms, load-testing trace pipelines, and showcasing distributed-system visualizations, for both traditional APM and LLM observability.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 One binary that generates a whole distributed system's telemetry: logs, traces and metrics from a 28-service topology with the shapes real systems actually make. Diamond dependencies, scatter-gather fan-out, sagas that compensate, timeouts that cascade. Point it at anything that speaks OTLP and watch it arrive.
 
-No Docker Compose. No microservices to deploy. No 6GB stack to babysit. One executable, or a 5.7 MB container.
+No Docker Compose. No microservices to deploy. No 6GB stack to babysit. One executable, or a 6.4 MB container.
 
 ```bash
 docker run --rm immersivefusion/snowglobe -insecure -endpoint host.docker.internal:4317

--- a/WHERE-SNOWGLOBE-RUNS.md
+++ b/WHERE-SNOWGLOBE-RUNS.md
@@ -1,6 +1,6 @@
 # Where Snowglobe Runs
 
-**One container. 5.7 MB. It runs anywhere, and this is the board of where it actually does.**
+**One container. 6.4 MB. It runs anywhere, and this is the board of where it actually does.**
 
 Snowglobe ships as a single distroless, multi-arch image (`linux/amd64` + `linux/arm64`), no Compose, no multi-gigabyte RAM footprint, no microservices to stand up:
 
@@ -27,7 +27,7 @@ That portability is the whole point: the same image runs on a laptop, a CI runne
   - **traditional**, when the AI tier goes down: the full traditional platform with its AI backends erroring (rate limits, timeouts).
   - **incident**, everything is on fire: maximum errors plus dead consumers, the root-cause / incident-response demo.
 - **Flavor:** the distroless container (`immersivefusion/snowglobe`, pinned by tag in GitOps and bumped by Renovate, the same pin-and-version we'd ask of you below), one Kubernetes Deployment per grid, each shipping to `otlp.deepcube.ai:443`. The three densest grids (ai-clean, traditional, incident) run at a low `-level` floor (full topology, gentle trace rate) so the 3D player stays smooth while all seven run side by side.
-- **The point:** the whole image is 5.7 MB and each grid sips a few dozen megabytes of RAM, light enough that the entire fleet would cheerfully run off a Mac mini in a broom closet. (It doesn't, it runs in the Immersive Fusion cloud, but it absolutely could.) **See them live, in 3D.** The way to experience this is [DeepCube](https://docs.deepcube.ai/DC/3D/), the immersive 3D client: install it, open a demo grid, and walk the live traces in three dimensions: fly the topology, drill into a failing span, lean on Tessa, our AI assistant. That's the real thing. On a phone, or can't install right now? [DeepCube Web](https://docs.deepcube.ai/DC/Web/) runs the same grids in your browser at [portal.deepcube.ai](https://portal.deepcube.ai), sign in and open a grid. Don't want to install or sign in at all? **Watch the grids live on Twitch** at [twitch.tv/immersivefusion](https://www.twitch.tv/immersivefusion): the 3D player, streamed in real time, zero friction.
+- **The point:** the whole image is 6.4 MB and each grid sips a few dozen megabytes of RAM, light enough that the entire fleet would cheerfully run off a Mac mini in a broom closet. (It doesn't, it runs in the Immersive Fusion cloud, but it absolutely could.) **See them live, in 3D.** The way to experience this is [DeepCube](https://docs.deepcube.ai/DC/3D/), the immersive 3D client: install it, open a demo grid, and walk the live traces in three dimensions: fly the topology, drill into a failing span, lean on Tessa, our AI assistant. That's the real thing. On a phone, or can't install right now? [DeepCube Web](https://docs.deepcube.ai/DC/Web/) runs the same grids in your browser at [portal.deepcube.ai](https://portal.deepcube.ai), sign in and open a grid. Don't want to install or sign in at all? **Watch the grids live on Twitch** at [twitch.tv/immersivefusion](https://www.twitch.tv/immersivefusion): the 3D player, streamed in real time, zero friction.
 
 ---
 

--- a/docs/metrics-design.md
+++ b/docs/metrics-design.md
@@ -80,6 +80,10 @@ conventions is to prefix with a reverse domain or an application name unique wit
 and it explicitly warns against extending an existing OTel namespace with a non-standard metric. So
 queue depth becomes `tracegen.messaging.queue.depth`, not `messaging.queue.depth`.
 
+The prefix keeps the old product name on purpose. A metric name is a wire contract:
+renaming it to `snowglobe.` would break every dashboard, alert and recording rule already
+keyed on it, for no gain a reader can see. Do not sweep it during a rename.
+
 Instrument names use dots. Do not pre-normalise to underscores: some backends preserve dots to the query
 surface and some translate them, and that is the backend's job, not the producer's.
 


### PR DESCRIPTION
Three leftovers from the rename. None were reached by the earlier README pass,
because that pass only looked at the README.

## The image size was wrong in four places

Every surface said **5.7 MB**. Measured against the registry today:

| tag | amd64 | arm64 |
|---|---|---|
| `latest`, `0.9.2` | **6.43 MB** | 5.94 MB |
| `0.9.1`, `0.9.0` | 6.42 MB | 5.93 MB |

The headline understated by ~13%. Corrected to **6.4 MB**, the amd64 figure,
because that is what nearly every reader pulls. Quoting the smaller arm64
number would have been the flattering choice and the wrong one.

**`DOCKERHUB.md` is the one that does not fix itself.** Its own header records
that it is the canonical source for the Docker Hub Overview and is pasted onto
the Hub page **by hand**, because the description API rejects PATs. So the wrong
figure stays live in the first paragraph, in front of every visitor, until
somebody re-pastes it. That step is not mine to run.

## The issue template asked for a binary that does not exist

`bug_report.md` asked reporters for "the exact `tracegen` invocation" and
pre-filled a code block with `tracegen ...`. The binary is `snowglobe` — this
repo's own README says so at line 53. Every bug reporter met a command that is
not on their machine.

`.golangci.yml:39` naming tracegen as the tool is the same class as the six
fixed in sos-beacon.

## Said why the metric prefix did not follow the rename

`docs/metrics-design.md` explains the `tracegen.` prefix across six lines and
never says it deliberately keeps the old product name. That is the document
someone reads *before* deciding the prefix looks stale, so it is where the
reason belongs.

## Left alone on purpose, verified not assumed

- The `tracegen.*` metric names, and the ~45 `tracegen.*` span attributes in
  `scenarios.go` / `scenarios_ai.go`. Same wire contract; renaming breaks every
  dashboard and alert keyed on them.
- The archived-image notes in `DOCKERHUB.md` and `release.yml` — load-bearing
  because they name the old repo.
- The old-path install note in the README — findable precisely because it says
  the old name.

## Verified

No `5.7 MB` remains anywhere; `.golangci.yml` still parses as version 2;
`go build ./...` exits 0; zero em dashes added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
