### PR TITLE
Ignore build output by extension, not by one filename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,14 @@
 # Build output
-tracegen.exe
+# Was `tracegen.exe`, which stopped matching the moment the binary was renamed to
+# snowglobe. A local `go build ./cmd/snowglobe` then drops a ~20MB untracked binary
+# in the repo root, one `git add -A` away from a public repo. Match on extension so
+# the next rename cannot reopen the hole.
+*.exe
 dist/
+
+# Runtime noise
+debug.log
+*.log
 
 # Test
 *.test


### PR DESCRIPTION
`.gitignore` line 2 was `tracegen.exe`. #35 renamed the module path and the binary to `snowglobe` on 2026-08-20, and the ignore rule was not renamed with it, so **it has matched nothing since**.

In a public repo that means `go build ./cmd/snowglobe` drops a ~20MB `snowglobe.exe` in the repo root that git no longer ignores, one `git add -A` away from being published.

**This already nearly happened.** A stale 20MB `tracegen.exe` was found sitting in the repo root on 2026-08-27 and deleted. It was never committed, so history is clean, but by luck rather than by the control that was meant to prevent it.

Matching on `*.exe` rather than a specific filename means the next rename cannot reopen the same hole. `debug.log` and `*.log` are ignored for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)