### PR TITLE
The headline describes -complexity heavy, not the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **A sealed world you can shake.**
 
-One binary that generates a whole distributed system's telemetry: logs, traces and metrics from a 28-service topology with the shapes real systems actually make. Diamond dependencies, scatter-gather fan-out, sagas that compensate, timeouts that cascade. Point it at anything that speaks OTLP and watch it arrive.
+One binary that generates a whole distributed system's telemetry: logs, traces and metrics from a topology of up to 28 services with the shapes real systems actually make. **The default (`-complexity normal`) runs 20 traditional services; `-complexity heavy` adds the 8 AI services for 28.** Diamond dependencies, scatter-gather fan-out, sagas that compensate, timeouts that cascade. Point it at anything that speaks OTLP and watch it arrive.
 
 No Docker Compose. No microservices to deploy. No 6GB stack to babysit. One executable, or a 6.4 MB container.
 
@@ -31,7 +31,7 @@ Every existing trace generator falls into one of two categories:
 
 And none of them generate **AI agentic traces**. The LLM observability market has no standalone tool that combines traditional APM with LLM observability. Every specialized LLM tool (Langfuse, LangSmith, Helicone, Arize, Traceloop, Portkey, Galileo) tracks token usage, model costs, and agent tool calls - but none of them provide traditional distributed tracing.
 
-This tool generates **topology-rich, failure-injectable traces from a single binary** - covering both traditional microservice flows AND AI agentic patterns with OTel GenAI semantic conventions. One binary proves that a platform can visualize both.
+This tool generates **topology-rich, failure-injectable traces from a single binary** - covering both traditional microservice flows AND AI agentic patterns with OTel GenAI semantic conventions. One binary proves that a platform can visualize both. **The AI services and their GenAI spans are in the `heavy` tier, so run `-complexity heavy` to get them; the default emits traditional traffic only.**
 
 ## Quick Start
 


### PR DESCRIPTION
The opening line promises **"a 28-service topology"** and the overview promises **AI agentic patterns with GenAI semantic conventions**. Neither is what the quick start produces.

Verified against `cmd/snowglobe/main.go`:

| `-complexity` | Services | AI services |
|---|---|---|
| light | 10 | 0 |
| **normal (default)** | **20** | **0** |
| heavy | 28 | 8 |

All 8 AI services are tier `heavy`. So someone who follows the quick start, runs `snowglobe -insecure`, and goes looking for the AI agent spans the README led with **finds none**, and counts 20 services rather than 28.

That is the class of gap a reader hits in the first two minutes and reports as a broken promise rather than a docs nit, because the headline is the reason they tried it in the first place.

Both claims now name the tier. **Nothing is withdrawn and no number changes**: 28 services and the GenAI spans are real, they just need `-complexity heavy`.

An alternative fix would be to make `heavy` the default. That is a product decision rather than a documentation one and is deliberately not made here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)