### PR TITLE
fix: clarify no-ai-backends behavior

### DIFF
--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -41,7 +41,7 @@ The image is multi-arch (`linux/amd64`, `linux/arm64`), distroless, and runs as 
 | `-errors` | `0` | Error rate 0-10 (0 = none, 5 = normal, 10 = chaos) |
 | `-complexity` | `normal` | Topology size: `light`, `normal`, `heavy` |
 | `-ai-only` | `false` | Only run AI agentic scenarios |
-| `-no-ai-backends` | `false` | Disable LLM/AI backends (AI spans emit errors) |
+| `-no-ai-backends` | `false` | Exclude LLM/AI services and scenarios from the topology |
 | `-no-consumers` | `false` | Publish to queues but never consume (backlog demo) |
 | `-no-logs` | `false` | Traces only, no OTel log records |
 

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Flags:
   -level int           Aggressiveness 1-10 (default 1)
   -errors int          Error rate 0-10 (default 0)
   -no-consumers        Disable all async consumers
-  -no-ai-backends      Disable LLM/AI backends (AI spans emit errors)
+  -no-ai-backends      Exclude LLM/AI services and scenarios from the topology
   -ai-only             Only run AI agentic scenarios
   -no-logs             Disable OTel log record emission (traces only)
   -no-metrics          Disable OTel metric emission
@@ -345,8 +345,8 @@ snowglobe -level 3 -no-consumers -insecure
 # AI scenarios only - great for LLM observability testing
 snowglobe -level 3 -ai-only -insecure
 
-# Simulate AI backend outage (LLM rate limits, timeouts)
-snowglobe -level 5 -no-ai-backends -errors 5 -insecure
+# Exclude AI services and scenarios from the heavy topology
+snowglobe -level 5 -complexity heavy -no-ai-backends -insecure
 
 # Chaos mode - maximum load and errors
 snowglobe -level 10 -errors 10 -insecure

--- a/cmd/snowglobe/main.go
+++ b/cmd/snowglobe/main.go
@@ -187,7 +187,7 @@ var consumersEnabled bool
 // insecureMode: when true, use plaintext gRPC (no TLS) for local backends
 var insecureMode bool
 
-// noAIBackends: when true, AI services are excluded (AI spans emit errors)
+// noAIBackends: when true, AI services and scenarios are excluded from the topology
 var noAIBackends bool
 
 // aiOnly: when true, only AI agentic scenarios are run
@@ -259,7 +259,7 @@ func main() {
 	errors := flag.Int("errors", 0, "error rate 0-10 (0=none, 5=normal, 10=chaos)")
 	noConsumers := flag.Bool("no-consumers", false, "disable all async consumers (messages published but never consumed)")
 	insecureFlag := flag.Bool("insecure", false, "use plaintext gRPC (no TLS) for local backends")
-	noAIBackendsFlag := flag.Bool("no-ai-backends", false, "exclude all LLM/AI services and scenarios from the topology (thier spans are absent, not failing)")
+	noAIBackendsFlag := flag.Bool("no-ai-backends", false, "exclude all LLM/AI services and scenarios from the topology (their spans are absent, not failing)")
 	aiOnlyFlag := flag.Bool("ai-only", false, "only run AI agentic scenarios")
 	complexityFlag := flag.String("complexity", "normal", "topology complexity: light, normal, heavy")
 	noLogsFlag := flag.Bool("no-logs", false, "disable OTel log record emission (traces only)")

--- a/cmd/snowglobe/main.go
+++ b/cmd/snowglobe/main.go
@@ -259,7 +259,7 @@ func main() {
 	errors := flag.Int("errors", 0, "error rate 0-10 (0=none, 5=normal, 10=chaos)")
 	noConsumers := flag.Bool("no-consumers", false, "disable all async consumers (messages published but never consumed)")
 	insecureFlag := flag.Bool("insecure", false, "use plaintext gRPC (no TLS) for local backends")
-	noAIBackendsFlag := flag.Bool("no-ai-backends", false, "disable all LLM/AI backends (AI spans emit errors)")
+	noAIBackendsFlag := flag.Bool("no-ai-backends", false, "exclude all LLM/AI services and scenarios from the topology (thier spans are absent, not failing)")
 	aiOnlyFlag := flag.Bool("ai-only", false, "only run AI agentic scenarios")
 	complexityFlag := flag.String("complexity", "normal", "topology complexity: light, normal, heavy")
 	noLogsFlag := flag.Bool("no-logs", false, "disable OTel log record emission (traces only)")


### PR DESCRIPTION
## Summary

- Clarify the `-no-ai-backends` CLI help to reflect that AI services and scenarios are excluded rather than failing.
- Update the README and Docker Hub documentation to match the actual behavior.
- Correct the README example so it demonstrates excluding AI components from the heavy topology rather than simulating an AI backend outage.

Fixes #42