### PR TITLE
docs: document commit signing and the branch rules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,36 @@ GOOS=windows GOARCH=amd64 go build -o snowglobe.exe ./cmd/snowglobe
 2. Keep changes focused: one logical change per PR.
 3. Run `go build ./...` and `go vet ./...` before pushing.
 4. Use clear, conventional commit messages (`feat:`, `fix:`, `docs:`, …).
-5. Open the PR against `main` and describe what changed and why.
+5. **Sign every commit** (see below). One unsigned commit blocks the merge.
+6. Open the PR against `main` and describe what changed and why.
+
+## Commit signing and branch rules
+
+`main` requires a **verified signature on every commit**, so a single unsigned commit
+anywhere in your branch blocks the merge even after the change is approved. Commits made
+in the GitHub web editor are signed automatically; commits pushed from your own machine
+are not, unless you have set that up. If you already push over SSH, reuse that key:
+
+```bash
+git config --global gpg.format ssh
+git config --global user.signingkey ~/.ssh/id_ed25519.pub
+git config --global commit.gpgsign true
+```
+
+Then add that same public key to <https://github.com/settings/keys> a second time as a
+**signing** key. `git log --show-signature -1` confirms it locally, and every commit in
+the pull request should show a green **Verified** badge.
+
+Already pushed something unsigned? `git rebase --exec 'git commit --amend --no-edit -S' main`
+re-signs the branch, then force-push it with lease.
+
+The rest of what `main` enforces: linear history (rebase onto `main`, do not merge it
+into your branch), one approving review, all review threads resolved, and squash or
+rebase merges only. A new push dismisses existing approvals, so batch your review fixes
+into one push where you can.
+
+The full version, including the GPG route, is in the
+[organization contribution guide](https://github.com/ImmersiveFusion/.github/blob/main/CONTRIBUTING.md).
 
 ## Releasing
 


### PR DESCRIPTION
Adds a **Commit signing and branch rules** section to `CONTRIBUTING.md`, plus one line in the pull request checklist pointing at it.

## Why

An outside contributor on `snowglobe#49` did good work, got it reviewed, fixed the review notes, and then the merge was blocked because one of the two commits was unsigned. Nothing in the repository said signing was required. The rule was real and enforced, but discoverable only by tripping over it, and that merge needed an override.

This guide had no mention of signing anywhere in it. Now it does.

## What the section says

- The SSH setup, three `git config` lines, plus the step people miss: the same key has to be added to GitHub a second time as a **signing** key, not just an authentication key.
- The trap that caught this contributor: commits made in the GitHub web editor are signed by GitHub automatically, commits pushed from your own machine are not. A branch starts verified and silently stops being verified.
- How to re-sign a branch that already has an unsigned commit on it, so the answer to "now what" is one command rather than a closed pull request.
- The rest of what `main` enforces: linear history, one approving review, threads resolved before merge, squash or rebase only, and the fact that a new push dismisses existing approvals.

The long version, including the GPG route and a table of what is enforced on each repository, lives in the new organization-wide guide at `ImmersiveFusion/.github`, which this links to. A repository-local `CONTRIBUTING.md` overrides the org default completely, which is why this repository needs its own copy of the essentials rather than inheriting them.

Every commit in this pull request is signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
